### PR TITLE
chore: h2-console web-allow-others 변경, Swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     //apply p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.8'
 
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ddd/moodof/MoodofApplication.java
+++ b/src/main/java/com/ddd/moodof/MoodofApplication.java
@@ -1,21 +1,13 @@
 package com.ddd.moodof;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-
-import javax.persistence.EntityManager;
 
 @SpringBootApplication
 public class MoodofApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(MoodofApplication.class, args);
-	}
-	@Bean
-	JPAQueryFactory jpaQueryFactory(EntityManager em){
-		return new JPAQueryFactory(em);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(MoodofApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/configuration/QuerydslConfig.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/configuration/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package com.ddd.moodof.adapter.infrastructure.configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/configuration/SwaggerConfig.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/configuration/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.ddd.moodof.adapter.infrastructure.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import static springfox.documentation.builders.RequestHandlerSelectors.basePackage;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(basePackage("com.ddd.moodof"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
   h2:
     console:
       enabled: true
+      settings:
+        web-allow-others: true
 logging.level:
   org.hibernate.SQL: debug
 # org.hibernate.type: trace


### PR DESCRIPTION
resolve #16 

- 배포된 서버에서 h2-console을 접속할수 있도록 web-allow-others 를 변경하였습니다.
- swagger 세팅을 추가했습니다. `http://localhost:8080/swagger-ui/` 로 접속할 수 있습니다.

- 머지 이후에 `https://moodof.tk/h2-console` `https://moodof.tk/swagger-ui/`로 접속 가능한지 확인 해야합니다.