### PR TITLE
feat: Board API 구현

### DIFF
--- a/src/main/java/com/ddd/moodof/adapter/presentation/BoardController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/BoardController.java
@@ -30,4 +30,11 @@ public class BoardController implements BoardAPI {
         BoardDTO.BoardResponse response = boardService.changeName(userId, id, request);
         return ResponseEntity.ok(response);
     }
+
+    @Override
+    @PutMapping("/{id}/previousBoardId")
+    public ResponseEntity<BoardDTO.BoardResponse> changeSequence(@LoginUserId Long userId, @PathVariable Long id, @RequestBody BoardDTO.ChangeBoardSequence request) {
+        BoardDTO.BoardResponse response = boardService.updateSequence(userId, id, request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/BoardController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/BoardController.java
@@ -37,4 +37,11 @@ public class BoardController implements BoardAPI {
         BoardDTO.BoardResponse response = boardService.updateSequence(userId, id, request);
         return ResponseEntity.ok(response);
     }
+
+    @Override
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BoardDTO.BoardResponse> delete(@LoginUserId Long userId, @PathVariable Long id) {
+        boardService.delete(userId, id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardAPI.java
@@ -4,10 +4,7 @@ import com.ddd.moodof.adapter.presentation.LoginUserId;
 import com.ddd.moodof.application.dto.BoardDTO;
 import io.swagger.annotations.ApiImplicitParam;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 public interface BoardAPI {
@@ -22,4 +19,8 @@ public interface BoardAPI {
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @PutMapping("/{id}/previousBoardId")
     ResponseEntity<BoardDTO.BoardResponse> changeSequence(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id, @RequestBody BoardDTO.ChangeBoardSequence request);
+
+    @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    @DeleteMapping("/{id}")
+    ResponseEntity<BoardDTO.BoardResponse> delete(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id);
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardAPI.java
@@ -18,4 +18,8 @@ public interface BoardAPI {
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @PutMapping("/{id}/name")
     ResponseEntity<BoardDTO.BoardResponse> changeName(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id, @RequestBody BoardDTO.ChangeBoardName request);
+
+    @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    @PutMapping("/{id}/previousBoardId")
+    ResponseEntity<BoardDTO.BoardResponse> changeSequence(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id, @RequestBody BoardDTO.ChangeBoardSequence request);
 }

--- a/src/main/java/com/ddd/moodof/application/BoardService.java
+++ b/src/main/java/com/ddd/moodof/application/BoardService.java
@@ -43,4 +43,13 @@ public class BoardService {
         Board updated = boardSequenceUpdater.update(board, request.getPreviousBoardId(), request.getCategoryId(), userId);
         return BoardDTO.BoardResponse.from(updated);
     }
+
+    public void delete(Long userId, Long id) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Board, id = " + id));
+        if (board.isUserNotEqual(userId)) {
+            throw new IllegalArgumentException("userId가 일치하지 않습니다. userId = " + userId);
+        }
+        boardRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/ddd/moodof/application/BoardService.java
+++ b/src/main/java/com/ddd/moodof/application/BoardService.java
@@ -1,10 +1,10 @@
 package com.ddd.moodof.application;
 
 import com.ddd.moodof.application.dto.BoardDTO;
+import com.ddd.moodof.application.verifier.BoardVerifier;
 import com.ddd.moodof.domain.model.board.Board;
 import com.ddd.moodof.domain.model.board.BoardRepository;
 import com.ddd.moodof.domain.model.board.BoardSequenceUpdater;
-import com.ddd.moodof.domain.model.board.BoardVerifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/ddd/moodof/application/CategoryService.java
+++ b/src/main/java/com/ddd/moodof/application/CategoryService.java
@@ -1,6 +1,7 @@
 package com.ddd.moodof.application;
 
 import com.ddd.moodof.application.dto.CategoryDTO;
+import com.ddd.moodof.domain.model.board.BoardRepository;
 import com.ddd.moodof.domain.model.category.Category;
 import com.ddd.moodof.domain.model.category.CategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.Optional;
 @Service
 public class CategoryService {
     private final CategoryRepository categoryRepository;
+    private final BoardRepository boardRepository;
 
     @Transactional
     public CategoryDTO.CategoryResponse create(CategoryDTO.CreateCategoryRequest request, Long userId) {
@@ -30,10 +32,12 @@ public class CategoryService {
         return CategoryDTO.CategoryResponse.from(saved);
     }
 
+    @Transactional
     public void deleteById(Long id, Long userId) {
         categoryRepository.findByIdAndUserId(id, userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다. " + id + " / " + userId));
         categoryRepository.deleteById(id);
+        boardRepository.deleteAllByCategoryId(id);
     }
 
     public List<CategoryDTO.CategoryResponse> findAllByUserId(Long userId){

--- a/src/main/java/com/ddd/moodof/application/CategoryService.java
+++ b/src/main/java/com/ddd/moodof/application/CategoryService.java
@@ -17,7 +17,6 @@ public class CategoryService {
 
     @Transactional
     public CategoryDTO.CategoryResponse create(CategoryDTO.CreateCategoryRequest request, Long userId) {
-        findOptionalById(request, userId);
         Category saved = categoryRepository.save(request.toEntity(userId));
         saveCategoryIntermediate(saved, request.getPreviousId());
         return CategoryDTO.CategoryResponse.from(saved);
@@ -55,11 +54,6 @@ public class CategoryService {
                 .filter(c -> !c.getId().equals(saved.getId()))
                 .findAny()
                 .ifPresent(cc -> cc.updatePreviousId(saved.getId()));
-    }
-
-    private void findOptionalById(CategoryDTO.CreateCategoryRequest request, Long userId) {
-        Optional<Category> category = categoryRepository.findByTitleAndUserId(request.getTitle(), userId);
-        category.ifPresent(s -> { throw new IllegalArgumentException("존재하는 카테고리 입니다."); });
     }
 
     private void updatePreviousId(Category target, Long previousId) {

--- a/src/main/java/com/ddd/moodof/application/TagAttachmentService.java
+++ b/src/main/java/com/ddd/moodof/application/TagAttachmentService.java
@@ -1,9 +1,9 @@
 package com.ddd.moodof.application;
 
 import com.ddd.moodof.application.dto.TagAttachmentDTO;
+import com.ddd.moodof.application.verifier.TagAttachmentVerifier;
 import com.ddd.moodof.domain.model.tag.attachment.TagAttachment;
 import com.ddd.moodof.domain.model.tag.attachment.TagAttachmentRepository;
-import com.ddd.moodof.domain.model.tag.attachment.TagAttachmentVerifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/ddd/moodof/application/dto/BoardDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/BoardDTO.java
@@ -45,4 +45,12 @@ public class BoardDTO {
     public static class ChangeBoardName {
         private String name;
     }
+
+    @NoArgsConstructor
+    @Getter
+    @AllArgsConstructor
+    public static class ChangeBoardSequence {
+        private Long categoryId;
+        private Long previousBoardId;
+    }
 }

--- a/src/main/java/com/ddd/moodof/application/verifier/BoardVerifier.java
+++ b/src/main/java/com/ddd/moodof/application/verifier/BoardVerifier.java
@@ -1,5 +1,6 @@
-package com.ddd.moodof.domain.model.board;
+package com.ddd.moodof.application.verifier;
 
+import com.ddd.moodof.domain.model.board.Board;
 import com.ddd.moodof.domain.model.category.Category;
 import com.ddd.moodof.domain.model.category.CategoryRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ddd/moodof/application/verifier/TagAttachmentVerifier.java
+++ b/src/main/java/com/ddd/moodof/application/verifier/TagAttachmentVerifier.java
@@ -1,7 +1,8 @@
-package com.ddd.moodof.domain.model.tag.attachment;
+package com.ddd.moodof.application.verifier;
 
 import com.ddd.moodof.domain.model.storage.photo.StoragePhotoRepository;
 import com.ddd.moodof.domain.model.tag.TagRepository;
+import com.ddd.moodof.domain.model.tag.attachment.TagAttachment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/ddd/moodof/domain/model/board/Board.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/Board.java
@@ -35,15 +35,12 @@ public class Board {
     @LastModifiedDate
     private LocalDateTime lastModifiedDate;
 
-    public void updatePreviousBoardId(Long userId, Long previousBoardId) {
+    public void changePreviousBoardId(Long previousBoardId, Long userId) {
         verify(userId);
-        this.previousBoardId = previousBoardId;
-    }
-
-    private void verify(Long userId) {
-        if (isNotEqual(userId)) {
-            throw new IllegalArgumentException("userId가 일치하지 않습니다.");
+        if (this.previousBoardId.equals(previousBoardId)) {
+            throw new IllegalArgumentException("previousBoardId가 같습니다.");
         }
+        this.previousBoardId = previousBoardId;
     }
 
     public void changeName(String name, Long userId) {
@@ -51,7 +48,23 @@ public class Board {
         this.name = name;
     }
 
-    public boolean isNotEqual(Long userId) {
+    public void updateSequence(Long previousBoardId, Long categoryId, Long userId) {
+        verify(userId);
+        this.previousBoardId = previousBoardId;
+        this.categoryId = categoryId;
+    }
+
+    private void verify(Long userId) {
+        if (isUserNotEqual(userId)) {
+            throw new IllegalArgumentException("userId가 일치하지 않습니다.");
+        }
+    }
+
+    public boolean isUserNotEqual(Long userId) {
         return !this.userId.equals(userId);
+    }
+
+    public boolean isCategoryEqual(Long categoryId) {
+        return false;
     }
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/Board.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/Board.java
@@ -35,14 +35,23 @@ public class Board {
     @LastModifiedDate
     private LocalDateTime lastModifiedDate;
 
-    public void updatePreviousBoardId(Long previousBoardId) {
+    public void updatePreviousBoardId(Long userId, Long previousBoardId) {
+        verify(userId);
         this.previousBoardId = previousBoardId;
     }
 
-    public void changeName(String name, Long userId) {
-        if (!this.userId.equals(userId)) {
+    private void verify(Long userId) {
+        if (isNotEqual(userId)) {
             throw new IllegalArgumentException("userId가 일치하지 않습니다.");
         }
+    }
+
+    public void changeName(String name, Long userId) {
+        verify(userId);
         this.name = name;
+    }
+
+    public boolean isNotEqual(Long userId) {
+        return !this.userId.equals(userId);
     }
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/Board.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/Board.java
@@ -63,8 +63,4 @@ public class Board {
     public boolean isUserNotEqual(Long userId) {
         return !this.userId.equals(userId);
     }
-
-    public boolean isCategoryEqual(Long categoryId) {
-        return false;
-    }
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
@@ -10,6 +10,4 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByPreviousBoardId(Long previousBoardId);
 
     Optional<Board> findByPreviousBoardIdAndCategoryId(Long previousBoardId, Long categoryId);
-
-    Optional<Board> findByPreviousBoardIdAndCategoryIdNot(Long previousBoardId, Long categoryId);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
@@ -10,4 +10,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByPreviousBoardId(Long previousBoardId);
 
     Optional<Board> findByPreviousBoardIdAndCategoryId(Long previousBoardId, Long categoryId);
+
+    void deleteAllByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    Optional<Board> findByPreviousBoardIdAndUserIdAndIdNot(Long previousBoardId, Long userId, Long id);
+    Optional<Board> findByPreviousBoardIdAndIdNot(Long previousBoardId, Long id);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
@@ -6,4 +6,10 @@ import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByPreviousBoardIdAndIdNot(Long previousBoardId, Long id);
+
+    Optional<Board> findByPreviousBoardId(Long previousBoardId);
+
+    Optional<Board> findByPreviousBoardIdAndCategoryId(Long previousBoardId, Long categoryId);
+
+    Optional<Board> findByPreviousBoardIdAndCategoryIdNot(Long previousBoardId, Long categoryId);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardSequenceUpdater.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardSequenceUpdater.java
@@ -1,0 +1,25 @@
+package com.ddd.moodof.domain.model.board;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class BoardSequenceUpdater {
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public Board update(Board board, Long previousBoardId, Long categoryId, Long userId) {
+        boardRepository.findByPreviousBoardId(board.getId())
+                .ifPresent(it -> it.changePreviousBoardId(board.getPreviousBoardId(), userId));
+
+        boardRepository.findByPreviousBoardIdAndCategoryId(previousBoardId, categoryId)
+                .ifPresent(it -> it.changePreviousBoardId(board.getId(), userId));
+
+        board.updateSequence(previousBoardId, categoryId, userId);
+
+        return boardRepository.save(board);
+    }
+}

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardVerifier.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardVerifier.java
@@ -1,0 +1,23 @@
+package com.ddd.moodof.domain.model.board;
+
+import com.ddd.moodof.domain.model.category.Category;
+import com.ddd.moodof.domain.model.category.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BoardVerifier {
+    private final CategoryRepository categoryRepository;
+
+    public Board toEntity(Long previousBoardId, Long categoryId, String name, Long userId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 category, id = " + categoryId));
+
+        if (category.isNotEqual(userId)) {
+            throw new IllegalArgumentException("카테고리 생성자와 로그인 유저의 아이디가 다릅니다.");
+        }
+
+        return new Board(null, previousBoardId, userId, name, categoryId, null, null);
+    }
+}

--- a/src/main/java/com/ddd/moodof/domain/model/category/Category.java
+++ b/src/main/java/com/ddd/moodof/domain/model/category/Category.java
@@ -46,4 +46,7 @@ public class Category {
         if (this.previousId.equals(previousId)) throw new IllegalArgumentException("동일한 previousId: " + previousId);
     }
 
+    public boolean isNotEqual(Long userId) {
+        return !this.userId.equals(userId);
+    }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -23,8 +24,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.List;
-import static com.ddd.moodof.adapter.presentation.CategoryController.API_CATEGORY;
+
 import static com.ddd.moodof.adapter.presentation.BoardController.API_BOARD;
+import static com.ddd.moodof.adapter.presentation.CategoryController.API_CATEGORY;
 import static com.ddd.moodof.adapter.presentation.StoragePhotoController.API_STORAGE_PHOTO;
 import static com.ddd.moodof.adapter.presentation.TagAttachmentController.API_TAG_ATTACHMENT;
 import static com.ddd.moodof.adapter.presentation.TagController.API_TAG;
@@ -32,6 +34,7 @@ import static com.ddd.moodof.adapter.presentation.TrashPhotoController.API_TRASH
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
@@ -71,6 +74,7 @@ public class AcceptanceTest {
         CategoryDTO.CreateCategoryRequest request = new CategoryDTO.CreateCategoryRequest(title,previousId);
         return postWithLogin(request, API_CATEGORY, CategoryDTO.CategoryResponse.class, userId);
     }
+
     protected CategoryDTO.CategoryResponse 카테고리_순서_변경(Long id,Long previousId, Long userId, String property){
         CategoryDTO.UpdateOrderCategoryRequest request = new CategoryDTO.UpdateOrderCategoryRequest(previousId);
         return putPropertyWithLogin(request, id, API_CATEGORY, CategoryDTO.CategoryResponse.class, userId, property);

--- a/src/test/java/com/ddd/moodof/acceptance/BoardAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/BoardAcceptanceTest.java
@@ -159,4 +159,13 @@ public class BoardAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(thirdBoard.getLastModifiedDate().isAfter(third.getLastModifiedDate())).isTrue()
         );
     }
+
+    @Test
+    void 보드를_삭제한다() {
+        // given
+        BoardDTO.BoardResponse board = 보드_생성(userId, 0L, category.getId(), "name");
+
+        // when then
+        deleteWithLogin(API_BOARD, board.getId(), userId);
+    }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/BoardAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/BoardAcceptanceTest.java
@@ -2,8 +2,11 @@ package com.ddd.moodof.acceptance;
 
 import com.ddd.moodof.application.dto.BoardDTO;
 import com.ddd.moodof.application.dto.CategoryDTO;
+import com.ddd.moodof.domain.model.board.Board;
+import com.ddd.moodof.domain.model.board.BoardRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.ddd.moodof.adapter.presentation.BoardController.API_BOARD;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,12 +14,17 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class BoardAcceptanceTest extends AcceptanceTest {
     private CategoryDTO.CategoryResponse category;
+    private CategoryDTO.CategoryResponse category2;
+
+    @Autowired
+    private BoardRepository boardRepository;
 
     @Override
     @BeforeEach
     void setUp() {
         super.setUp();
         category = 카테고리_생성(userId, "title", 0L);
+        category2 = 카테고리_생성(userId, "title", category.getId());
     }
 
     @Test
@@ -59,6 +67,96 @@ public class BoardAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.getName()).isEqualTo(changed),
                 () -> assertThat(response.getCreatedDate()).isEqualTo(board.getCreatedDate()),
                 () -> assertThat(response.getLastModifiedDate().isAfter(response.getCreatedDate())).isTrue()
+        );
+    }
+
+    @Test
+    void 보드_순서를_변경한다() {
+        // given
+        BoardDTO.BoardResponse first = 보드_생성(userId, 0L, category.getId(), "name");
+        BoardDTO.BoardResponse second = 보드_생성(userId, first.getId(), category.getId(), "name");
+        BoardDTO.BoardResponse third = 보드_생성(userId, second.getId(), category.getId(), "name");
+
+        // when
+        long previousBoardId = 0L;
+        BoardDTO.ChangeBoardSequence request = new BoardDTO.ChangeBoardSequence(category.getId(), previousBoardId);
+        BoardDTO.BoardResponse response = putPropertyWithLogin(request, second.getId(), API_BOARD, BoardDTO.BoardResponse.class, userId, "previousBoardId");
+
+        Board thirdBoard = boardRepository.findById(third.getId()).get();
+        Board firstBoard = boardRepository.findById(first.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo(second.getId()),
+                () -> assertThat(response.getPreviousBoardId()).isEqualTo(previousBoardId),
+                () -> assertThat(response.getLastModifiedDate().isAfter(response.getCreatedDate())).isTrue(),
+
+                () -> assertThat(thirdBoard.getPreviousBoardId()).isEqualTo(first.getId()),
+                () -> assertThat(thirdBoard.getLastModifiedDate().isAfter(third.getLastModifiedDate())).isTrue(),
+
+                () -> assertThat(firstBoard.getPreviousBoardId()).isEqualTo(second.getId()),
+                () -> assertThat(firstBoard.getLastModifiedDate().isAfter(first.getLastModifiedDate())).isTrue()
+        );
+    }
+
+    @Test
+    void 보드_순서를_변경한다_first_to_second() {
+        // given
+        BoardDTO.BoardResponse first = 보드_생성(userId, 0L, category.getId(), "name");
+        BoardDTO.BoardResponse second = 보드_생성(userId, first.getId(), category.getId(), "name");
+        BoardDTO.BoardResponse third = 보드_생성(userId, second.getId(), category.getId(), "name");
+
+        // when
+        long previousBoardId = 2L;
+        BoardDTO.ChangeBoardSequence request = new BoardDTO.ChangeBoardSequence(category.getId(), previousBoardId);
+        BoardDTO.BoardResponse response = putPropertyWithLogin(request, first.getId(), API_BOARD, BoardDTO.BoardResponse.class, userId, "previousBoardId");
+
+        Board secondBoard = boardRepository.findById(second.getId()).get();
+        Board thirdBoard = boardRepository.findById(third.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo(first.getId()),
+                () -> assertThat(response.getPreviousBoardId()).isEqualTo(previousBoardId),
+                () -> assertThat(response.getLastModifiedDate().isAfter(response.getCreatedDate())).isTrue(),
+
+                () -> assertThat(secondBoard.getPreviousBoardId()).isEqualTo(0L),
+                () -> assertThat(secondBoard.getLastModifiedDate().isAfter(second.getLastModifiedDate())).isTrue(),
+
+                () -> assertThat(thirdBoard.getPreviousBoardId()).isEqualTo(first.getId()),
+                () -> assertThat(thirdBoard.getLastModifiedDate().isAfter(third.getLastModifiedDate())).isTrue()
+        );
+    }
+
+    @Test
+    void 보드_순서를_변경한다_cross_category() {
+        // given
+        BoardDTO.BoardResponse first = 보드_생성(userId, 0L, category.getId(), "name");
+        BoardDTO.BoardResponse second = 보드_생성(userId, first.getId(), category.getId(), "name");
+        BoardDTO.BoardResponse third = 보드_생성(userId, second.getId(), category.getId(), "name");
+        BoardDTO.BoardResponse differentCategoryFirst = 보드_생성(userId, 0L, category2.getId(), "name");
+        BoardDTO.BoardResponse differentCategorySecond = 보드_생성(userId, differentCategoryFirst.getId(), category2.getId(), "name");
+        BoardDTO.BoardResponse differentCategoryThird = 보드_생성(userId, differentCategorySecond.getId(), category2.getId(), "name");
+
+        // when
+        long previousBoardId = second.getId();
+        BoardDTO.ChangeBoardSequence request = new BoardDTO.ChangeBoardSequence(category.getId(), previousBoardId);
+        BoardDTO.BoardResponse response = putPropertyWithLogin(request, differentCategorySecond.getId(), API_BOARD, BoardDTO.BoardResponse.class, userId, "previousBoardId");
+
+        Board thirdBoard = boardRepository.findById(third.getId()).get();
+        Board differentCategoryThirdBoard = boardRepository.findById(differentCategoryThird.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(response.getId()).isEqualTo(differentCategorySecond.getId()),
+                () -> assertThat(response.getPreviousBoardId()).isEqualTo(previousBoardId),
+                () -> assertThat(response.getLastModifiedDate().isAfter(response.getCreatedDate())).isTrue(),
+
+                () -> assertThat(differentCategoryThirdBoard.getPreviousBoardId()).isEqualTo(differentCategoryFirst.getId()),
+                () -> assertThat(differentCategoryThirdBoard.getLastModifiedDate().isAfter(second.getLastModifiedDate())).isTrue(),
+
+                () -> assertThat(thirdBoard.getPreviousBoardId()).isEqualTo(differentCategorySecond.getId()),
+                () -> assertThat(thirdBoard.getLastModifiedDate().isAfter(third.getLastModifiedDate())).isTrue()
         );
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/BoardAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/BoardAcceptanceTest.java
@@ -1,6 +1,8 @@
 package com.ddd.moodof.acceptance;
 
 import com.ddd.moodof.application.dto.BoardDTO;
+import com.ddd.moodof.application.dto.CategoryDTO;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.ddd.moodof.adapter.presentation.BoardController.API_BOARD;
@@ -8,23 +10,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class BoardAcceptanceTest extends AcceptanceTest {
+    private CategoryDTO.CategoryResponse category;
+
+    @Override
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+        category = 카테고리_생성(userId, "title", 0L);
+    }
 
     @Test
     void 보드를_생성한다() {
-        // given
-        // TODO: 2021/05/05 카테고리 생성 후 변경
-        long categoryId = 1L;
-
         // when
         long previousBoardId = 0L;
         String name = "name";
-        BoardDTO.BoardResponse response = 보드_생성(userId, previousBoardId, categoryId, name);
+        BoardDTO.BoardResponse response = 보드_생성(userId, previousBoardId, category.getId(), name);
 
         // then
         assertAll(
                 () -> assertThat(response.getId()).isNotNull(),
                 () -> assertThat(response.getPreviousBoardId()).isEqualTo(previousBoardId),
-                () -> assertThat(response.getCategoryId()).isEqualTo(categoryId),
+                () -> assertThat(response.getCategoryId()).isEqualTo(category.getId()),
                 () -> assertThat(response.getUserId()).isEqualTo(userId),
                 () -> assertThat(response.getName()).isEqualTo(name),
                 () -> assertThat(response.getCreatedDate()).isNotNull(),
@@ -36,10 +42,8 @@ public class BoardAcceptanceTest extends AcceptanceTest {
     void 보드_이름을_수정한다() {
         // given
         long previousBoardId = 0L;
-        // TODO: 2021/05/05 카테고리 생성 후 변경
-        long categoryId = 1L;
         String name = "name";
-        BoardDTO.BoardResponse board = 보드_생성(userId, previousBoardId, categoryId, name);
+        BoardDTO.BoardResponse board = 보드_생성(userId, previousBoardId, category.getId(), name);
 
         // when
         String changed = "changed";

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -3,8 +3,6 @@ package com.ddd.moodof.acceptance;
 import com.ddd.moodof.adapter.infrastructure.aws.S3FileUploader;
 import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import com.ddd.moodof.application.dto.TagDTO;
-import com.ddd.moodof.domain.model.user.User;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.util.UriComponentsBuilder;


### PR DESCRIPTION
resolve #36 

- 카테고리 삭제시 카테고리에 속한 보드도 삭제하도록 하였습니다.
- 카테고리 생성시 이름 중복이 가능하도록 변경하였습니다.