### PR TITLE
feat: 보관함 사진 상세 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-    //apply querydsl
-    implementation 'com.querydsl:querydsl-jpa'
+    implementation "com.querydsl:querydsl-jpa:4.4.0"
+    implementation "com.querydsl:querydsl-apt:4.4.0"
 
     //apply p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.8'
@@ -60,19 +60,28 @@ test {
     useJUnitPlatform()
 }
 //apply querydsl directory path
-def querydslDir = "$buildDir/generated/querydsl"
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
+def generatedSourcesDir = file("${buildDir}/generated/querydsl")
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
-sourceSets {
-    main.java.srcDir querydslDir
-}
+
 configurations {
     querydsl.extendsFrom compileClasspath
 }
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
+
+sourceSets {
+    main {
+        java {
+            srcDir generatedSourcesDir
+        }
+    }
+}
+
+querydsl {
+    querydslSourcesDir = relativePath(generatedSourcesDir)
+    library = "com.querydsl:querydsl-apt"
+    jpa = true
 }
 
 processResources.dependsOn('copySecret')

--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
@@ -1,12 +1,15 @@
 package com.ddd.moodof.adapter.infrastructure.persistence.querydsl;
 
 import com.ddd.moodof.adapter.infrastructure.persistence.PaginationUtils;
-import com.ddd.moodof.application.dto.StoragePhotoDTO;
+import com.ddd.moodof.application.dto.*;
 import com.ddd.moodof.domain.model.storage.photo.StoragePhoto;
 import com.ddd.moodof.domain.model.storage.photo.StoragePhotoQueryRepository;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilderFactory;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +18,17 @@ import org.springframework.data.jpa.repository.support.Querydsl;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import static com.ddd.moodof.domain.model.board.QBoard.board;
+import static com.ddd.moodof.domain.model.board.photo.QBoardPhoto.boardPhoto;
+import static com.ddd.moodof.domain.model.category.QCategory.category;
 import static com.ddd.moodof.domain.model.storage.photo.QStoragePhoto.storagePhoto;
+import static com.ddd.moodof.domain.model.tag.QTag.tag;
 import static com.ddd.moodof.domain.model.tag.attachment.QTagAttachment.tagAttachment;
 import static com.ddd.moodof.domain.model.trash.photo.QTrashPhoto.trashPhoto;
 
@@ -42,18 +52,19 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
     }
 
     private JPAQuery<StoragePhotoDTO.StoragePhotoResponse> getQuery(Long userId, List<Long> tagIds) {
-        JPAQuery<StoragePhotoDTO.StoragePhotoResponse> storagePhotoQuery = jpaQueryFactory.select(Projections.constructor(StoragePhotoDTO.StoragePhotoResponse.class,
-                storagePhoto.id,
-                storagePhoto.userId,
-                storagePhoto.uri,
-                storagePhoto.representativeColor,
-                storagePhoto.createdDate,
-                storagePhoto.lastModifiedDate
-        ))
+        JPAQuery<StoragePhotoDTO.StoragePhotoResponse> storagePhotoQuery = jpaQueryFactory
+                .select(Projections.constructor(StoragePhotoDTO.StoragePhotoResponse.class,
+                        storagePhoto.id,
+                        storagePhoto.userId,
+                        storagePhoto.uri,
+                        storagePhoto.representativeColor,
+                        storagePhoto.createdDate,
+                        storagePhoto.lastModifiedDate
+                ))
                 .from(storagePhoto)
                 .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId));
 
-        BooleanExpression excludeTrash = storagePhoto.userId.eq(userId).and(trashPhoto.id.isNull());
+        BooleanExpression excludeTrash = excludeTrash(userId);
 
         if (Objects.isNull(tagIds) || tagIds.isEmpty()) {
             return storagePhotoQuery
@@ -62,5 +73,127 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
         return storagePhotoQuery
                 .leftJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
                 .where(excludeTrash.and(tagAttachment.tagId.in(tagIds)));
+    }
+
+    private BooleanExpression excludeTrash(Long userId) {
+        return storagePhoto.userId.eq(userId).and(trashPhoto.id.isNull());
+    }
+
+    @Override
+    public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id) {
+        StoragePhotoDTO.StoragePhotoDetailResponse storagePhotoDetailResponse = jpaQueryFactory
+                .select(new QStoragePhotoDTO_StoragePhotoDetailResponse(
+                        storagePhoto.id,
+                        storagePhoto.userId,
+                        storagePhoto.uri,
+                        storagePhoto.representativeColor,
+                        storagePhoto.createdDate,
+                        storagePhoto.lastModifiedDate,
+                        ExpressionUtils.as(previousStoragePhotoId(userId, id), "previousStoragePhotoId"),
+                        ExpressionUtils.as(nextStoragePhotoId(userId, id), "nextStoragePhotoId")))
+                .from(storagePhoto)
+                .where(storagePhoto.id.eq(id))
+                .fetchOne();
+
+        storagePhotoDetailResponse.setCategories(findCategories(id));
+        storagePhotoDetailResponse.setTags(findTags(id));
+
+        return storagePhotoDetailResponse;
+    }
+
+    private JPQLQuery<Long> previousStoragePhotoId(Long userId, Long id) {
+        return JPAExpressions
+                .select(storagePhoto.id)
+                .from(storagePhoto)
+                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(minModifiedDate(userId, id))));
+    }
+
+    private JPQLQuery<LocalDateTime> minModifiedDate(Long userId, Long id) {
+        return JPAExpressions
+                .select(storagePhoto.lastModifiedDate.min())
+                .from(storagePhoto)
+                .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
+                .where(excludeTrash(userId).and(storagePhoto.lastModifiedDate.after(storagePhotoModifiedDate(id))));
+    }
+
+    private JPQLQuery<LocalDateTime> storagePhotoModifiedDate(Long id) {
+        return JPAExpressions
+                .select(storagePhoto.lastModifiedDate)
+                .from(storagePhoto)
+                .where(storagePhoto.id.eq(id));
+    }
+
+    private JPQLQuery<Long> nextStoragePhotoId(Long userId, Long id) {
+        return JPAExpressions
+                .select(storagePhoto.id)
+                .from(storagePhoto)
+                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(maxModifiedDate(userId, id))));
+    }
+
+    private JPQLQuery<LocalDateTime> maxModifiedDate(Long userId, Long id) {
+        return JPAExpressions
+                .select(storagePhoto.lastModifiedDate.max())
+                .from(storagePhoto)
+                .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
+                .where(excludeTrash(userId).and(storagePhoto.lastModifiedDate.before(storagePhotoModifiedDate(id))));
+    }
+
+    private List<CategoryDTO.CategoryDetailResponse> findCategories(Long storagePhotoId) {
+        List<BoardDTO.BoardResponse> boards = findBoards(storagePhotoId);
+
+        List<Long> boardIds = boards.stream()
+                .map(BoardDTO.BoardResponse::getCategoryId)
+                .collect(Collectors.toList());
+
+        Map<Long, List<BoardDTO.BoardResponse>> boardsByCategoryId = boards.stream()
+                .collect(Collectors.groupingBy(BoardDTO.BoardResponse::getCategoryId));
+
+        List<CategoryDTO.CategoryDetailResponse> categories = jpaQueryFactory
+                .select(new QCategoryDTO_CategoryDetailResponse(
+                        category.id,
+                        category.userId,
+                        category.title,
+                        category.previousId,
+                        category.createdDate,
+                        category.lastModifiedDate
+                ))
+                .from(category)
+                .where(category.id.in(boardIds))
+                .fetch();
+
+        categories.forEach(it -> it.setBoards(boardsByCategoryId.get(it.getId())));
+        return categories;
+    }
+
+    private List<BoardDTO.BoardResponse> findBoards(Long storagePhotoId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(BoardDTO.BoardResponse.class,
+                        board.id,
+                        board.previousBoardId,
+                        board.userId,
+                        board.name,
+                        board.categoryId,
+                        board.createdDate,
+                        board.lastModifiedDate
+                ))
+                .from(board)
+                .innerJoin(boardPhoto).on(board.id.eq(boardPhoto.boardId))
+                .where(boardPhoto.storagePhotoId.eq(storagePhotoId))
+                .fetch();
+    }
+
+    private List<TagDTO.TagResponse> findTags(Long id) {
+        return jpaQueryFactory
+                .select(Projections.constructor(TagDTO.TagResponse.class,
+                        tag.id,
+                        tag.userId,
+                        tag.name,
+                        tag.createdDate,
+                        tag.lastModifiedDate
+                ))
+                .from(tag)
+                .innerJoin(tagAttachment).on(tag.id.eq(tagAttachment.tagId))
+                .where(tagAttachment.storagePhotoId.eq(id))
+                .fetch();
     }
 }

--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
@@ -105,10 +105,10 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
         return JPAExpressions
                 .select(storagePhoto.id)
                 .from(storagePhoto)
-                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(minModifiedDate(userId, id))));
+                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(lastModifiedDateAfterStoragePhoto(userId, id))));
     }
 
-    private JPQLQuery<LocalDateTime> minModifiedDate(Long userId, Long id) {
+    private JPQLQuery<LocalDateTime> lastModifiedDateAfterStoragePhoto(Long userId, Long id) {
         return JPAExpressions
                 .select(storagePhoto.lastModifiedDate.min())
                 .from(storagePhoto)
@@ -127,10 +127,10 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
         return JPAExpressions
                 .select(storagePhoto.id)
                 .from(storagePhoto)
-                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(maxModifiedDate(userId, id))));
+                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(lastModifiedDateBeforeStoragePhoto(userId, id))));
     }
 
-    private JPQLQuery<LocalDateTime> maxModifiedDate(Long userId, Long id) {
+    private JPQLQuery<LocalDateTime> lastModifiedDateBeforeStoragePhoto(Long userId, Long id) {
         return JPAExpressions
                 .select(storagePhoto.lastModifiedDate.max())
                 .from(storagePhoto)

--- a/src/main/java/com/ddd/moodof/adapter/presentation/BoardPhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/BoardPhotoController.java
@@ -1,0 +1,34 @@
+package com.ddd.moodof.adapter.presentation;
+
+import com.ddd.moodof.adapter.presentation.api.BoardPhotoAPI;
+import com.ddd.moodof.application.BoardPhotoService;
+import com.ddd.moodof.application.dto.BoardPhotoDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+
+@RequiredArgsConstructor
+@RequestMapping(BoardPhotoController.API_BOARD_PHOTO)
+@RestController
+public class BoardPhotoController implements BoardPhotoAPI {
+    public static final String API_BOARD_PHOTO = "/api/board-photos";
+
+    private final BoardPhotoService boardPhotoService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<BoardPhotoDTO.BoardPhotoResponse> addPhoto(@LoginUserId Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request) {
+        BoardPhotoDTO.BoardPhotoResponse response = boardPhotoService.addPhoto(userId, request);
+        return ResponseEntity.created(URI.create(API_BOARD_PHOTO + "/" + response.getId())).body(response);
+    }
+
+    @Override
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> removePhoto(@LoginUserId Long userId, @PathVariable Long id) {
+        boardPhotoService.removePhoto(userId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ddd/moodof/adapter/presentation/StoragePhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/StoragePhotoController.java
@@ -40,8 +40,16 @@ public class StoragePhotoController implements StoragePhotoAPI {
             @RequestParam(required = false, value = "tagIds") List<Long> tagIds) {
 
         StoragePhotoDTO.StoragePhotoPageResponse response = storagePhotoService.findPage(userId, page, size, sortBy, descending, tagIds);
-        return ResponseEntity.ok(response);
 
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/{id}")
+    public ResponseEntity<StoragePhotoDTO.StoragePhotoDetailResponse> findDetail(@LoginUserId Long userId, @PathVariable Long id) {
+        StoragePhotoDTO.StoragePhotoDetailResponse response = storagePhotoService.findDetail(userId, id);
+
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardPhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardPhotoAPI.java
@@ -1,0 +1,20 @@
+package com.ddd.moodof.adapter.presentation.api;
+
+import com.ddd.moodof.application.dto.BoardPhotoDTO;
+import io.swagger.annotations.ApiImplicitParam;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import springfox.documentation.annotations.ApiIgnore;
+
+public interface BoardPhotoAPI {
+    @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    @PostMapping
+    ResponseEntity<BoardPhotoDTO.BoardPhotoResponse> addPhoto(@ApiIgnore Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request);
+
+    @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> removePhoto(@ApiIgnore Long userId, @PathVariable Long id);
+}

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/StoragePhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/StoragePhotoAPI.java
@@ -27,6 +27,10 @@ public interface StoragePhotoAPI {
             @RequestParam(required = false, value = "tagIds[]") List<Long> tagIds);
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    @GetMapping("/{id}")
+    ResponseEntity<StoragePhotoDTO.StoragePhotoDetailResponse> findDetail(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id);
+
+    @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @DeleteMapping("/{id}")
     ResponseEntity<Void> deleteById(@ApiIgnore Long userId, @PathVariable Long id);
 }

--- a/src/main/java/com/ddd/moodof/application/BoardPhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/BoardPhotoService.java
@@ -1,0 +1,32 @@
+package com.ddd.moodof.application;
+
+import com.ddd.moodof.application.dto.BoardPhotoDTO;
+import com.ddd.moodof.application.verifier.BoardPhotoVerifier;
+import com.ddd.moodof.domain.model.board.photo.BoardPhoto;
+import com.ddd.moodof.domain.model.board.photo.BoardPhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BoardPhotoService {
+    private final BoardPhotoRepository boardPhotoRepository;
+    private final BoardPhotoVerifier boardPhotoVerifier;
+
+    public BoardPhotoDTO.BoardPhotoResponse addPhoto(Long userId, BoardPhotoDTO.AddBoardPhoto request) {
+        BoardPhoto boardPhoto = boardPhotoVerifier.toEntity(userId, request.getStoragePhotoId(), request.getBoardId());
+        BoardPhoto saved = boardPhotoRepository.save(boardPhoto);
+        return BoardPhotoDTO.BoardPhotoResponse.from(saved);
+    }
+
+    public void removePhoto(Long userId, Long id) {
+        BoardPhoto boardPhoto = boardPhotoRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 BoardPhoto, id : " + id));
+
+        if (boardPhoto.isUserNotEqual(userId)) {
+            throw new IllegalArgumentException("로그인한 유저와 BoardPhoto를 생성한 유저의 아이디가 다릅니다.");
+        }
+
+        boardPhotoRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ddd/moodof/application/StoragePhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/StoragePhotoService.java
@@ -39,4 +39,8 @@ public class StoragePhotoService {
         }
         storagePhotoRepository.deleteById(id);
     }
+
+    public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id) {
+        return storagePhotoQueryRepository.findDetail(userId, id);
+    }
 }

--- a/src/main/java/com/ddd/moodof/application/dto/BoardPhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/BoardPhotoDTO.java
@@ -1,0 +1,34 @@
+package com.ddd.moodof.application.dto;
+
+import com.ddd.moodof.domain.model.board.photo.BoardPhoto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class BoardPhotoDTO {
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class BoardPhotoResponse {
+        private Long id;
+        private Long storagePhotoId;
+        private Long boardId;
+        private Long userId;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+
+        public static BoardPhotoResponse from(BoardPhoto boardPhoto) {
+            return new BoardPhotoResponse(boardPhoto.getId(), boardPhoto.getStoragePhotoId(), boardPhoto.getBoardId(), boardPhoto.getUserId(), boardPhoto.getCreatedDate(), boardPhoto.getLastModifiedDate());
+        }
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class AddBoardPhoto {
+        private Long storagePhotoId;
+        private Long boardId;
+    }
+}

--- a/src/main/java/com/ddd/moodof/application/dto/CategoryDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/CategoryDTO.java
@@ -1,6 +1,7 @@
 package com.ddd.moodof.application.dto;
 
 import com.ddd.moodof.domain.model.category.Category;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -88,5 +89,32 @@ public class CategoryDTO {
     @Getter
     public static class UpdateOrderCategoryRequest {
         private Long previousId;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class CategoryDetailResponse {
+        private Long id;
+        private Long userId;
+        private String title;
+        private Long previousId;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+        private List<BoardDTO.BoardResponse> boards;
+
+        @QueryProjection
+        public CategoryDetailResponse(Long id, Long userId, String title, Long previousId, LocalDateTime createdDate, LocalDateTime lastModifiedDate) {
+            this.id = id;
+            this.userId = userId;
+            this.title = title;
+            this.previousId = previousId;
+            this.createdDate = createdDate;
+            this.lastModifiedDate = lastModifiedDate;
+        }
+
+        public void setBoards(List<BoardDTO.BoardResponse> boards) {
+            this.boards = boards;
+        }
     }
 }

--- a/src/main/java/com/ddd/moodof/application/dto/StoragePhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/StoragePhotoDTO.java
@@ -1,6 +1,7 @@
 package com.ddd.moodof.application.dto;
 
 import com.ddd.moodof.domain.model.storage.photo.StoragePhoto;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,5 +55,41 @@ public class StoragePhotoDTO {
     public static class StoragePhotoPageResponse {
         private long totalPageCount;
         private List<StoragePhotoResponse> storagePhotos;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class StoragePhotoDetailResponse {
+        private Long id;
+        private Long userId;
+        private String uri;
+        private String representativeColor;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+        private Long previousStoragePhotoId;
+        private Long nextStoragePhotoId;
+        private List<CategoryDTO.CategoryDetailResponse> categories;
+        private List<TagDTO.TagResponse> tags;
+
+        @QueryProjection
+        public StoragePhotoDetailResponse(Long id, Long userId, String uri, String representativeColor, LocalDateTime createdDate, LocalDateTime lastModifiedDate, Long previousStoragePhotoId, Long nextStoragePhotoId) {
+            this.id = id;
+            this.userId = userId;
+            this.uri = uri;
+            this.representativeColor = representativeColor;
+            this.createdDate = createdDate;
+            this.lastModifiedDate = lastModifiedDate;
+            this.previousStoragePhotoId = previousStoragePhotoId;
+            this.nextStoragePhotoId = nextStoragePhotoId;
+        }
+
+        public void setCategories(List<CategoryDTO.CategoryDetailResponse> categories) {
+            this.categories = categories;
+        }
+
+        public void setTags(List<TagDTO.TagResponse> tags) {
+            this.tags = tags;
+        }
     }
 }

--- a/src/main/java/com/ddd/moodof/application/dto/TagDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/TagDTO.java
@@ -25,7 +25,7 @@ public class TagDTO {
                     .id(null)
                     .userId(userId)
                     .name(name)
-                    .createdTime(null)
+                    .createdDate(null)
                     .lastModifiedDate(null)
                     .build();
         }
@@ -43,7 +43,7 @@ public class TagDTO {
                     .id(id)
                     .userId(userId)
                     .name(name)
-                    .createdTime(null)
+                    .createdDate(null)
                     .lastModifiedDate(null)
                     .build();
         }
@@ -66,7 +66,7 @@ public class TagDTO {
                     .id(tag.getId())
                     .userId(tag.getUserId())
                     .name(tag.getName())
-                    .createdDate(tag.getCreatedTime())
+                    .createdDate(tag.getCreatedDate())
                     .lastModifiedDate(tag.getLastModifiedDate())
                     .build();
         }
@@ -76,7 +76,7 @@ public class TagDTO {
                     .id(tag.getId())
                     .userId(tag.getUserId())
                     .name(tag.getName())
-                    .createdDate(tag.getCreatedTime())
+                    .createdDate(tag.getCreatedDate())
                     .lastModifiedDate(tag.getLastModifiedDate())
                     .build()).collect(Collectors.toList());
         }

--- a/src/main/java/com/ddd/moodof/application/verifier/BoardPhotoVerifier.java
+++ b/src/main/java/com/ddd/moodof/application/verifier/BoardPhotoVerifier.java
@@ -1,0 +1,21 @@
+package com.ddd.moodof.application.verifier;
+
+import com.ddd.moodof.domain.model.board.BoardRepository;
+import com.ddd.moodof.domain.model.board.photo.BoardPhoto;
+import com.ddd.moodof.domain.model.storage.photo.StoragePhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BoardPhotoVerifier {
+    private final StoragePhotoRepository storagePhotoRepository;
+    private final BoardRepository boardRepository;
+
+    public BoardPhoto toEntity(Long userId, Long storagePhotoId, Long boardId) {
+        if (storagePhotoRepository.existsByIdAndUserId(storagePhotoId, userId) && boardRepository.existsByIdAndUserId(boardId, userId)) {
+            return new BoardPhoto(null, storagePhotoId, boardId, userId, null, null);
+        }
+        throw new IllegalArgumentException("보관함 사진 또는 보드가 존재하지 않습니다. storagePhotoId : " + storagePhotoId + ", boardId : " + boardId);
+    }
+}

--- a/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/BoardRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByPreviousBoardIdAndUserIdAndIdNot(Long previousBoardId, Long userId, Long id);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhoto.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhoto.java
@@ -1,0 +1,38 @@
+package com.ddd.moodof.domain.model.board.photo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class BoardPhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long storagePhotoId;
+
+    private Long boardId;
+
+    private Long userId;
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @CreatedDate
+    private LocalDateTime lastModifiedDate;
+
+    public boolean isUserNotEqual(Long userId) {
+        return !this.userId.equals(userId);
+    }
+}

--- a/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhotoRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhotoRepository.java
@@ -1,0 +1,6 @@
+package com.ddd.moodof.domain.model.board.photo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
+}

--- a/src/main/java/com/ddd/moodof/domain/model/storage/photo/StoragePhotoQueryRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/storage/photo/StoragePhotoQueryRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface StoragePhotoQueryRepository {
     StoragePhotoDTO.StoragePhotoPageResponse findPageExcludeTrash(Long userId, Pageable pageable, List<Long> tagIds);
+
+    StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/tag/Tag.java
+++ b/src/main/java/com/ddd/moodof/domain/model/tag/Tag.java
@@ -24,7 +24,7 @@ public class Tag {
     private String name;
 
     @CreatedDate
-    private LocalDateTime createdTime;
+    private LocalDateTime createdDate;
 
     @LastModifiedDate
     private LocalDateTime lastModifiedDate;

--- a/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
@@ -23,8 +23,10 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.List;
-import static com.ddd.moodof.adapter.presentation.CategoryController.API_CATEGORY;
+
 import static com.ddd.moodof.adapter.presentation.BoardController.API_BOARD;
+import static com.ddd.moodof.adapter.presentation.BoardPhotoController.API_BOARD_PHOTO;
+import static com.ddd.moodof.adapter.presentation.CategoryController.API_CATEGORY;
 import static com.ddd.moodof.adapter.presentation.StoragePhotoController.API_STORAGE_PHOTO;
 import static com.ddd.moodof.adapter.presentation.TagAttachmentController.API_TAG_ATTACHMENT;
 import static com.ddd.moodof.adapter.presentation.TagController.API_TAG;
@@ -239,5 +241,10 @@ public class AcceptanceTest {
     protected TagAttachmentDTO.TagAttachmentResponse 태그붙이기_생성(Long userId, Long storagePhotoId, Long tagId) {
         TagAttachmentDTO.CreateTagAttachment request = new TagAttachmentDTO.CreateTagAttachment(storagePhotoId, tagId);
         return postWithLogin(request, API_TAG_ATTACHMENT, TagAttachmentDTO.TagAttachmentResponse.class, userId);
+    }
+
+    protected BoardPhotoDTO.BoardPhotoResponse 보드_사진_생성(Long userId, Long storagePhotoId, Long boardId) {
+        BoardPhotoDTO.AddBoardPhoto request = new BoardPhotoDTO.AddBoardPhoto(storagePhotoId, boardId);
+        return postWithLogin(request, API_BOARD_PHOTO, BoardPhotoDTO.BoardPhotoResponse.class, userId);
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/BoardPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/BoardPhotoAcceptanceTest.java
@@ -1,49 +1,52 @@
 package com.ddd.moodof.acceptance;
 
+import com.ddd.moodof.application.dto.BoardDTO;
+import com.ddd.moodof.application.dto.BoardPhotoDTO;
+import com.ddd.moodof.application.dto.CategoryDTO;
 import com.ddd.moodof.application.dto.StoragePhotoDTO;
-import com.ddd.moodof.application.dto.TagAttachmentDTO;
-import com.ddd.moodof.application.dto.TagDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.ddd.moodof.adapter.presentation.TagAttachmentController.API_TAG_ATTACHMENT;
+import static com.ddd.moodof.adapter.presentation.BoardPhotoController.API_BOARD_PHOTO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class TagAttachmentAcceptanceTest extends AcceptanceTest {
+public class BoardPhotoAcceptanceTest extends AcceptanceTest {
     private StoragePhotoDTO.StoragePhotoResponse storagePhoto;
-    private TagDTO.TagResponse tag;
+    private BoardDTO.BoardResponse board;
+    private CategoryDTO.CategoryResponse category;
 
     @Override
     @BeforeEach
     void setUp() {
         super.setUp();
         storagePhoto = 보관함사진_생성(userId, "photoUri", "representativeColor");
-        tag = 태그_생성(userId, "tag");
+        category = 카테고리_생성(userId, "title", 0L);
+        board = 보드_생성(userId, 0L, category.getId(), "name");
     }
 
     @Test
-    void 보관함사진에_태그를_붙인다() {
+    void 보드에_보관함사진을_추가한다() {
         // when
-        TagAttachmentDTO.TagAttachmentResponse response = 태그붙이기_생성(userId, storagePhoto.getId(), tag.getId());
+        BoardPhotoDTO.BoardPhotoResponse response = 보드_사진_생성(userId, storagePhoto.getId(), board.getId());
 
         // then
         assertAll(
                 () -> assertThat(response.getId()).isNotNull(),
                 () -> assertThat(response.getUserId()).isEqualTo(userId),
                 () -> assertThat(response.getStoragePhotoId()).isEqualTo(storagePhoto.getId()),
-                () -> assertThat(response.getTagId()).isEqualTo(tag.getId()),
+                () -> assertThat(response.getBoardId()).isEqualTo(board.getId()),
                 () -> assertThat(response.getCreatedDate()).isNotNull(),
                 () -> assertThat(response.getLastModifiedDate()).isEqualTo(response.getCreatedDate())
         );
     }
 
     @Test
-    void 보관함사진에_태그를_뗀다() {
+    void 보드에서_보관함사진을_제거한다() {
         // given
-        TagAttachmentDTO.TagAttachmentResponse response = 태그붙이기_생성(userId, storagePhoto.getId(), tag.getId());
+        BoardPhotoDTO.BoardPhotoResponse response = 보드_사진_생성(userId, storagePhoto.getId(), board.getId());
 
         // when then
-        deleteWithLogin(API_TAG_ATTACHMENT, response.getId(), userId);
+        deleteWithLogin(API_BOARD_PHOTO, response.getId(), userId);
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
+import java.util.List;
 
 import static com.ddd.moodof.adapter.presentation.StoragePhotoController.API_STORAGE_PHOTO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -144,6 +145,7 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         StoragePhotoDTO.StoragePhotoResponse storagePhoto2 = 보관함사진_생성(userId, "2", "2");
         StoragePhotoDTO.StoragePhotoResponse storagePhoto3 = 보관함사진_생성(userId, "3", "3");
         StoragePhotoDTO.StoragePhotoResponse storagePhoto4 = 보관함사진_생성(userId, "4", "4");
+        StoragePhotoDTO.StoragePhotoResponse storagePhoto5 = 보관함사진_생성(userId, "5", "5");
         CategoryDTO.CategoryResponse category1 = 카테고리_생성(userId, "category-1", 0L);
         CategoryDTO.CategoryResponse category2 = 카테고리_생성(userId, "category-2", category1.getId());
         BoardDTO.BoardResponse board1 = 보드_생성(userId, 0L, category1.getId(), "board-1");
@@ -159,6 +161,7 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         TagDTO.TagResponse tag2 = 태그_생성(userId, "tag-2");
         태그붙이기_생성(userId, storagePhoto2.getId(), tag1.getId());
         태그붙이기_생성(userId, storagePhoto2.getId(), tag2.getId());
+        보관함사진_휴지통_이동(List.of(storagePhoto3.getId(), storagePhoto4.getId()), userId);
 
         // when
         StoragePhotoDTO.StoragePhotoDetailResponse response = getWithLogin(API_STORAGE_PHOTO + "/" + storagePhoto2.getId(), StoragePhotoDTO.StoragePhotoDetailResponse.class, userId);
@@ -168,7 +171,7 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.getId()).isEqualTo(storagePhoto2.getId()),
                 () -> assertThat(response.getCreatedDate()).isEqualTo(storagePhoto2.getCreatedDate()),
                 () -> assertThat(response.getLastModifiedDate()).isEqualTo(storagePhoto2.getLastModifiedDate()),
-                () -> assertThat(response.getPreviousStoragePhotoId()).isEqualTo(storagePhoto3.getId()),
+                () -> assertThat(response.getPreviousStoragePhotoId()).isEqualTo(storagePhoto5.getId()),
                 () -> assertThat(response.getNextStoragePhotoId()).isEqualTo(storagePhoto1.getId()),
                 () -> assertThat(response.getCategories().size()).isEqualTo(2L),
                 () -> assertThat(response.getTags().size()).isEqualTo(2L)


### PR DESCRIPTION
resolve #43 

- 쿼리 한번에 조회하려 하였으나, JPQL Projection 에서 Collection을 지원하지 않는다고 합니다. 
  - [링크](https://stackoverflow.com/questions/17116711/collections-in-querydsl-projections)
  - 추후 쿼리 개선하게 된다면 JPQL이 아니라 jdbc나 mybatis 같은걸 사용해서 직접 쿼리를 작성해야할 것 같습니다.
- 이전 아이디와 다음 아이디를 구하는 과정에서도 서브 쿼리에서 limit을 사용할 수 없는 이슈로 쿼리가 조금 복잡해졌습니다.
  - [링크](https://stackoverflow.com/questions/8555485/how-to-impose-limit-on-sub-query-of-jpa-query)
  - 이 역시, 직접 쿼리를 작성하게 된다면 개선시킬 수 있을 것 같습니다. (order by modifiedDate desc limit 1)