### PR TITLE
feat: 사진 조회 관련 보충 구현

### DIFF
--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
@@ -35,6 +35,8 @@ import static com.ddd.moodof.domain.model.trash.photo.QTrashPhoto.trashPhoto;
 @RequiredArgsConstructor
 @Repository
 public class StoragePhotoQuerydslRepository implements StoragePhotoQueryRepository {
+    private static final long NO_TAG = 0L;
+
     private final EntityManager em;
     private final JPAQueryFactory jpaQueryFactory;
     private final PaginationUtils paginationUtils;
@@ -70,8 +72,13 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
             return storagePhotoQuery
                     .where(excludeTrash);
         }
+        if (tagIds.contains(NO_TAG)) {
+            return storagePhotoQuery
+                    .leftJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
+                    .where(excludeTrash.and(tagAttachment.tagId.in(tagIds).or(tagAttachment.id.isNull())));
+        }
         return storagePhotoQuery
-                .leftJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
+                .innerJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
                 .where(excludeTrash.and(tagAttachment.tagId.in(tagIds)));
     }
 
@@ -80,7 +87,7 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
     }
 
     @Override
-    public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id) {
+    public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id, List<Long> tagIds) {
         StoragePhotoDTO.StoragePhotoDetailResponse storagePhotoDetailResponse = jpaQueryFactory
                 .select(new QStoragePhotoDTO_StoragePhotoDetailResponse(
                         storagePhoto.id,
@@ -89,8 +96,8 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
                         storagePhoto.representativeColor,
                         storagePhoto.createdDate,
                         storagePhoto.lastModifiedDate,
-                        ExpressionUtils.as(previousStoragePhotoId(userId, id), "previousStoragePhotoId"),
-                        ExpressionUtils.as(nextStoragePhotoId(userId, id), "nextStoragePhotoId")))
+                        ExpressionUtils.as(previousStoragePhotoId(userId, id, tagIds), "previousStoragePhotoId"),
+                        ExpressionUtils.as(nextStoragePhotoId(userId, id, tagIds), "nextStoragePhotoId")))
                 .from(storagePhoto)
                 .where(storagePhoto.id.eq(id))
                 .fetchOne();
@@ -101,19 +108,36 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
         return storagePhotoDetailResponse;
     }
 
-    private JPQLQuery<Long> previousStoragePhotoId(Long userId, Long id) {
+    private JPQLQuery<Long> previousStoragePhotoId(Long userId, Long id, List<Long> tagIds) {
         return JPAExpressions
                 .select(storagePhoto.id)
                 .from(storagePhoto)
-                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(lastModifiedDateAfterStoragePhoto(userId, id))));
+                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(lastModifiedDateAfterStoragePhoto(userId, id, tagIds))));
     }
 
-    private JPQLQuery<LocalDateTime> lastModifiedDateAfterStoragePhoto(Long userId, Long id) {
+    private JPQLQuery<LocalDateTime> lastModifiedDateAfterStoragePhoto(Long userId, Long id, List<Long> tagIds) {
+        if (tagIds.isEmpty()) {
+            return JPAExpressions
+                    .select(storagePhoto.lastModifiedDate.min())
+                    .from(storagePhoto)
+                    .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
+                    .where(excludeTrash(userId).and(storagePhoto.lastModifiedDate.after(storagePhotoModifiedDate(id))));
+        }
+        if (tagIds.contains(NO_TAG)) {
+            return JPAExpressions
+                    .select(storagePhoto.lastModifiedDate.min())
+                    .from(storagePhoto)
+                    .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
+                    .leftJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
+                    .where(excludeTrash(userId).and(tagAttachment.tagId.in(tagIds).or(tagAttachment.id.isNull())).and(storagePhoto.lastModifiedDate.after(storagePhotoModifiedDate(id))));
+        }
+
         return JPAExpressions
                 .select(storagePhoto.lastModifiedDate.min())
                 .from(storagePhoto)
                 .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
-                .where(excludeTrash(userId).and(storagePhoto.lastModifiedDate.after(storagePhotoModifiedDate(id))));
+                .innerJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
+                .where(excludeTrash(userId).and(tagAttachment.tagId.in(tagIds)).and(storagePhoto.lastModifiedDate.after(storagePhotoModifiedDate(id))));
     }
 
     private JPQLQuery<LocalDateTime> storagePhotoModifiedDate(Long id) {
@@ -123,19 +147,35 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
                 .where(storagePhoto.id.eq(id));
     }
 
-    private JPQLQuery<Long> nextStoragePhotoId(Long userId, Long id) {
+    private JPQLQuery<Long> nextStoragePhotoId(Long userId, Long id, List<Long> tagIds) {
         return JPAExpressions
                 .select(storagePhoto.id)
                 .from(storagePhoto)
-                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(lastModifiedDateBeforeStoragePhoto(userId, id))));
+                .where(storagePhoto.userId.eq(userId).and(storagePhoto.lastModifiedDate.eq(lastModifiedDateBeforeStoragePhoto(userId, id, tagIds))));
     }
 
-    private JPQLQuery<LocalDateTime> lastModifiedDateBeforeStoragePhoto(Long userId, Long id) {
+    private JPQLQuery<LocalDateTime> lastModifiedDateBeforeStoragePhoto(Long userId, Long id, List<Long> tagIds) {
+        if (tagIds.isEmpty()) {
+            return JPAExpressions
+                    .select(storagePhoto.lastModifiedDate.max())
+                    .from(storagePhoto)
+                    .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
+                    .where(excludeTrash(userId).and(storagePhoto.lastModifiedDate.before(storagePhotoModifiedDate(id))));
+        }
+        if (tagIds.contains(NO_TAG)) {
+            return JPAExpressions
+                    .select(storagePhoto.lastModifiedDate.max())
+                    .from(storagePhoto)
+                    .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
+                    .leftJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
+                    .where(excludeTrash(userId).and(tagAttachment.tagId.in(tagIds).or(tagAttachment.id.isNull())).and(storagePhoto.lastModifiedDate.before(storagePhotoModifiedDate(id))));
+        }
         return JPAExpressions
                 .select(storagePhoto.lastModifiedDate.max())
                 .from(storagePhoto)
                 .leftJoin(trashPhoto).on(storagePhoto.id.eq(trashPhoto.storagePhotoId))
-                .where(excludeTrash(userId).and(storagePhoto.lastModifiedDate.before(storagePhotoModifiedDate(id))));
+                .innerJoin(tagAttachment).on(storagePhoto.id.eq(tagAttachment.storagePhotoId))
+                .where(excludeTrash(userId).and(tagAttachment.tagId.in(tagIds)).and(storagePhoto.lastModifiedDate.before(storagePhotoModifiedDate(id))));
     }
 
     private List<CategoryDTO.CategoryDetailResponse> findCategories(Long storagePhotoId) {

--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/StoragePhotoQuerydslRepository.java
@@ -50,7 +50,9 @@ public class StoragePhotoQuerydslRepository implements StoragePhotoQueryReposito
                 .applyPagination(pageable, jpaQuery)
                 .fetch();
 
-        return new StoragePhotoDTO.StoragePhotoPageResponse(paginationUtils.getTotalPageCount(jpaQuery.fetchCount(), pageable.getPageSize()), responses);
+        long totalCount = jpaQuery.fetchCount();
+
+        return new StoragePhotoDTO.StoragePhotoPageResponse(totalCount, paginationUtils.getTotalPageCount(totalCount, pageable.getPageSize()), responses);
     }
 
     private JPAQuery<StoragePhotoDTO.StoragePhotoResponse> getQuery(Long userId, List<Long> tagIds) {

--- a/src/main/java/com/ddd/moodof/adapter/presentation/BoardPhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/BoardPhotoController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -20,15 +20,15 @@ public class BoardPhotoController implements BoardPhotoAPI {
 
     @Override
     @PostMapping
-    public ResponseEntity<BoardPhotoDTO.BoardPhotoResponse> addPhoto(@LoginUserId Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request) {
-        BoardPhotoDTO.BoardPhotoResponse response = boardPhotoService.addPhoto(userId, request);
-        return ResponseEntity.created(URI.create(API_BOARD_PHOTO + "/" + response.getId())).body(response);
+    public ResponseEntity<List<BoardPhotoDTO.BoardPhotoResponse>> addPhotos(@LoginUserId Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request) {
+        List<BoardPhotoDTO.BoardPhotoResponse> responses = boardPhotoService.addPhotos(userId, request);
+        return ResponseEntity.ok(responses);
     }
 
     @Override
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> removePhoto(@LoginUserId Long userId, @PathVariable Long id) {
-        boardPhotoService.removePhoto(userId, id);
+    @DeleteMapping
+    public ResponseEntity<Void> removePhoto(@LoginUserId Long userId, @RequestBody BoardPhotoDTO.RemoveBoardPhotos request) {
+        boardPhotoService.removePhoto(userId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/BoardPhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/BoardPhotoController.java
@@ -26,6 +26,13 @@ public class BoardPhotoController implements BoardPhotoAPI {
     }
 
     @Override
+    @GetMapping
+    public ResponseEntity<List<BoardPhotoDTO.BoardPhotoResponse>> findAllByBoard(@LoginUserId Long userId, @RequestParam Long boardId) {
+        List<BoardPhotoDTO.BoardPhotoResponse> responses = boardPhotoService.findAllByBoardId(boardId, userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Override
     @DeleteMapping
     public ResponseEntity<Void> removePhoto(@LoginUserId Long userId, @RequestBody BoardPhotoDTO.RemoveBoardPhotos request) {
         boardPhotoService.removePhoto(userId, request);

--- a/src/main/java/com/ddd/moodof/adapter/presentation/StoragePhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/StoragePhotoController.java
@@ -46,8 +46,11 @@ public class StoragePhotoController implements StoragePhotoAPI {
 
     @Override
     @GetMapping("/{id}")
-    public ResponseEntity<StoragePhotoDTO.StoragePhotoDetailResponse> findDetail(@LoginUserId Long userId, @PathVariable Long id) {
-        StoragePhotoDTO.StoragePhotoDetailResponse response = storagePhotoService.findDetail(userId, id);
+    public ResponseEntity<StoragePhotoDTO.StoragePhotoDetailResponse> findDetail(
+            @LoginUserId Long userId,
+            @PathVariable Long id,
+            @RequestParam(required = false, value = "tagIds") List<Long> tagIds) {
+        StoragePhotoDTO.StoragePhotoDetailResponse response = storagePhotoService.findDetail(userId, id, tagIds);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardPhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardPhotoAPI.java
@@ -1,20 +1,22 @@
 package com.ddd.moodof.adapter.presentation.api;
 
+import com.ddd.moodof.adapter.presentation.LoginUserId;
 import com.ddd.moodof.application.dto.BoardPhotoDTO;
 import io.swagger.annotations.ApiImplicitParam;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import springfox.documentation.annotations.ApiIgnore;
 
+import java.util.List;
+
 public interface BoardPhotoAPI {
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @PostMapping
-    ResponseEntity<BoardPhotoDTO.BoardPhotoResponse> addPhoto(@ApiIgnore Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request);
+    ResponseEntity<List<BoardPhotoDTO.BoardPhotoResponse>> addPhotos(@ApiIgnore Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request);
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
-    @DeleteMapping("/{id}")
-    ResponseEntity<Void> removePhoto(@ApiIgnore Long userId, @PathVariable Long id);
+    @DeleteMapping
+    ResponseEntity<Void> removePhoto(@ApiIgnore @LoginUserId Long userId, @RequestBody BoardPhotoDTO.RemoveBoardPhotos request);
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardPhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/BoardPhotoAPI.java
@@ -4,9 +4,7 @@ import com.ddd.moodof.adapter.presentation.LoginUserId;
 import com.ddd.moodof.application.dto.BoardPhotoDTO;
 import io.swagger.annotations.ApiImplicitParam;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.List;
@@ -15,6 +13,10 @@ public interface BoardPhotoAPI {
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @PostMapping
     ResponseEntity<List<BoardPhotoDTO.BoardPhotoResponse>> addPhotos(@ApiIgnore Long userId, @RequestBody BoardPhotoDTO.AddBoardPhoto request);
+
+    @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    @GetMapping
+    ResponseEntity<List<BoardPhotoDTO.BoardPhotoResponse>> findAllByBoard(@ApiIgnore @LoginUserId Long userId, @RequestParam Long boardId);
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @DeleteMapping

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/StoragePhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/StoragePhotoAPI.java
@@ -28,7 +28,7 @@ public interface StoragePhotoAPI {
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @GetMapping("/{id}")
-    ResponseEntity<StoragePhotoDTO.StoragePhotoDetailResponse> findDetail(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id);
+    ResponseEntity<StoragePhotoDTO.StoragePhotoDetailResponse> findDetail(@ApiIgnore @LoginUserId Long userId, @PathVariable Long id, @RequestParam(required = false, value = "tagIds[]") List<Long> tagIds);
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @DeleteMapping("/{id}")

--- a/src/main/java/com/ddd/moodof/application/BoardPhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/BoardPhotoService.java
@@ -7,26 +7,49 @@ import com.ddd.moodof.domain.model.board.photo.BoardPhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Service
 public class BoardPhotoService {
+    private static final long FIRST_PREVIOUS_BOARD_PHOTO_ID = 0L;
+
     private final BoardPhotoRepository boardPhotoRepository;
     private final BoardPhotoVerifier boardPhotoVerifier;
 
-    public BoardPhotoDTO.BoardPhotoResponse addPhoto(Long userId, BoardPhotoDTO.AddBoardPhoto request) {
-        BoardPhoto boardPhoto = boardPhotoVerifier.toEntity(userId, request.getStoragePhotoId(), request.getBoardId());
-        BoardPhoto saved = boardPhotoRepository.save(boardPhoto);
-        return BoardPhotoDTO.BoardPhotoResponse.from(saved);
+    public List<BoardPhotoDTO.BoardPhotoResponse> addPhotos(Long userId, BoardPhotoDTO.AddBoardPhoto request) {
+        // TODO: 2021/05/25 StoragePhoto 삭제 대응
+        List<BoardPhoto> boardPhotos = boardPhotoVerifier.toEntities(userId, request.getStoragePhotoIds(), request.getBoardId());
+        Optional<BoardPhoto> recentest = boardPhotoRepository.findFirstByBoardIdOrderByLastModifiedDateDesc(request.getBoardId());
+        if (recentest.isPresent()) {
+            return BoardPhotoDTO.BoardPhotoResponse.listFrom(saveWithSequence(boardPhotos, recentest.get().getId()));
+        }
+        return BoardPhotoDTO.BoardPhotoResponse.listFrom(saveWithSequence(boardPhotos, FIRST_PREVIOUS_BOARD_PHOTO_ID));
     }
 
-    public void removePhoto(Long userId, Long id) {
-        BoardPhoto boardPhoto = boardPhotoRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 BoardPhoto, id : " + id));
+    private List<BoardPhoto> saveWithSequence(List<BoardPhoto> boardPhotos, Long previousId) {
+        List<BoardPhoto> result = new ArrayList<>();
+        Long previousBoardPhotoId = previousId;
 
-        if (boardPhoto.isUserNotEqual(userId)) {
+        for (BoardPhoto boardPhoto : boardPhotos) {
+            boardPhoto.setPreviousBoardPhotoId(previousBoardPhotoId);
+            BoardPhoto saved = boardPhotoRepository.save(boardPhoto);
+
+            result.add(saved);
+            previousBoardPhotoId = saved.getId();
+        }
+        return result;
+    }
+
+    public void removePhoto(Long userId, BoardPhotoDTO.RemoveBoardPhotos request) {
+        List<BoardPhoto> boardPhotos = boardPhotoRepository.findAllById(request.getBoardPhotoIds());
+
+        if (boardPhotos.stream().anyMatch(boardPhoto -> boardPhoto.isUserNotEqual(userId))) {
             throw new IllegalArgumentException("로그인한 유저와 BoardPhoto를 생성한 유저의 아이디가 다릅니다.");
         }
 
-        boardPhotoRepository.deleteById(id);
+        boardPhotoRepository.deleteAll(boardPhotos);
     }
 }

--- a/src/main/java/com/ddd/moodof/application/BoardPhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/BoardPhotoService.java
@@ -52,4 +52,9 @@ public class BoardPhotoService {
 
         boardPhotoRepository.deleteAll(boardPhotos);
     }
+
+    public List<BoardPhotoDTO.BoardPhotoResponse> findAllByBoardId(Long boardId, Long userId) {
+        List<BoardPhoto> boardPhotos = boardPhotoRepository.findAllByBoardIdAndUserId(boardId, userId);
+        return BoardPhotoDTO.BoardPhotoResponse.listFrom(boardPhotos);
+    }
 }

--- a/src/main/java/com/ddd/moodof/application/StoragePhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/StoragePhotoService.java
@@ -40,7 +40,7 @@ public class StoragePhotoService {
         storagePhotoRepository.deleteById(id);
     }
 
-    public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id) {
-        return storagePhotoQueryRepository.findDetail(userId, id);
+    public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id, List<Long> tagIds) {
+        return storagePhotoQueryRepository.findDetail(userId, id, tagIds);
     }
 }

--- a/src/main/java/com/ddd/moodof/application/dto/BoardPhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/BoardPhotoDTO.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class BoardPhotoDTO {
     @NoArgsConstructor
@@ -16,11 +18,18 @@ public class BoardPhotoDTO {
         private Long storagePhotoId;
         private Long boardId;
         private Long userId;
+        private Long previousBoardPhotoId;
         private LocalDateTime createdDate;
         private LocalDateTime lastModifiedDate;
 
         public static BoardPhotoResponse from(BoardPhoto boardPhoto) {
-            return new BoardPhotoResponse(boardPhoto.getId(), boardPhoto.getStoragePhotoId(), boardPhoto.getBoardId(), boardPhoto.getUserId(), boardPhoto.getCreatedDate(), boardPhoto.getLastModifiedDate());
+            return new BoardPhotoResponse(boardPhoto.getId(), boardPhoto.getStoragePhotoId(), boardPhoto.getBoardId(), boardPhoto.getUserId(), boardPhoto.getPreviousBoardPhotoId(), boardPhoto.getCreatedDate(), boardPhoto.getLastModifiedDate());
+        }
+
+        public static List<BoardPhotoResponse> listFrom(List<BoardPhoto> boardPhotos) {
+            return boardPhotos.stream()
+                    .map(BoardPhotoResponse::from)
+                    .collect(Collectors.toList());
         }
     }
 
@@ -28,7 +37,14 @@ public class BoardPhotoDTO {
     @AllArgsConstructor
     @Getter
     public static class AddBoardPhoto {
-        private Long storagePhotoId;
+        private List<Long> storagePhotoIds;
         private Long boardId;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class RemoveBoardPhotos {
+        private List<Long> boardPhotoIds;
     }
 }

--- a/src/main/java/com/ddd/moodof/application/dto/CategoryDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/CategoryDTO.java
@@ -1,6 +1,5 @@
 package com.ddd.moodof.application.dto;
 
-import com.ddd.moodof.domain.model.board.Board;
 import com.ddd.moodof.domain.model.category.Category;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
@@ -10,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -44,7 +42,7 @@ public class CategoryDTO {
                     .build();
         }
 
-        public static List<CategoryResponse> listForm(List<Category> categories) {
+        public static List<CategoryResponse> listFrom(List<Category> categories) {
             return categories.stream().map(category -> CategoryResponse.builder()
                     .id(category.getId())
                     .userId(category.getUserId())
@@ -61,7 +59,7 @@ public class CategoryDTO {
     @AllArgsConstructor
     @Getter
     @Builder
-    public static class CategoryWithBoardResponse{
+    public static class CategoryWithBoardResponse {
 
         private Long id;
 
@@ -75,7 +73,7 @@ public class CategoryDTO {
 
         private LocalDateTime lastModifiedDate;
 
-        private List<BoardDTO.BoardResponse> boardList = new ArrayList<>();
+        private List<BoardDTO.BoardResponse> boardList;
 
         public static CategoryWithBoardResponse from(CategoryDTO.CategoryResponse category, List<BoardDTO.BoardResponse> boards) {
             return CategoryWithBoardResponse.builder()
@@ -110,7 +108,8 @@ public class CategoryDTO {
                     .lastModifiedDate(null)
                     .build();
         }
-        public Category toEntity(Long userId, String title, Long previousId){
+
+        public Category toEntity(Long userId, String title, Long previousId) {
             return Category.builder()
                     .id(null)
                     .previousId(previousId)

--- a/src/main/java/com/ddd/moodof/application/dto/StoragePhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/StoragePhotoDTO.java
@@ -53,6 +53,7 @@ public class StoragePhotoDTO {
     @Getter
     @AllArgsConstructor
     public static class StoragePhotoPageResponse {
+        private long totalStoragePhotoCount;
         private long totalPageCount;
         private List<StoragePhotoResponse> storagePhotos;
     }

--- a/src/main/java/com/ddd/moodof/application/verifier/BoardPhotoVerifier.java
+++ b/src/main/java/com/ddd/moodof/application/verifier/BoardPhotoVerifier.java
@@ -6,16 +6,25 @@ import com.ddd.moodof.domain.model.storage.photo.StoragePhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Component
 public class BoardPhotoVerifier {
     private final StoragePhotoRepository storagePhotoRepository;
     private final BoardRepository boardRepository;
 
-    public BoardPhoto toEntity(Long userId, Long storagePhotoId, Long boardId) {
-        if (storagePhotoRepository.existsByIdAndUserId(storagePhotoId, userId) && boardRepository.existsByIdAndUserId(boardId, userId)) {
-            return new BoardPhoto(null, storagePhotoId, boardId, userId, null, null);
+    public List<BoardPhoto> toEntities(Long userId, List<Long> storagePhotoIds, Long boardId) {
+        if (storagePhotoRepository.existsByIdInAndUserId(storagePhotoIds, userId) && boardRepository.existsByIdAndUserId(boardId, userId)) {
+            return storagePhotoIds.stream()
+                    .map(storagePhotoId -> new BoardPhoto(null, storagePhotoId, boardId, userId, null, null, null))
+                    .collect(Collectors.toList());
         }
-        throw new IllegalArgumentException("보관함 사진 또는 보드가 존재하지 않습니다. storagePhotoId : " + storagePhotoId + ", boardId : " + boardId);
+        throw new IllegalArgumentException("보관함 사진 또는 보드가 존재하지 않습니다. storagePhotoIds : " +
+                storagePhotoIds.stream()
+                        .map(Object::toString)
+                        .collect(Collectors.joining(",")) +
+                ", boardId : " + boardId);
     }
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhoto.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhoto.java
@@ -26,6 +26,8 @@ public class BoardPhoto {
 
     private Long userId;
 
+    private Long previousBoardPhotoId;
+
     @CreatedDate
     private LocalDateTime createdDate;
 
@@ -34,5 +36,9 @@ public class BoardPhoto {
 
     public boolean isUserNotEqual(Long userId) {
         return !this.userId.equals(userId);
+    }
+
+    public void setPreviousBoardPhotoId(Long previousBoardPhotoId) {
+        this.previousBoardPhotoId = previousBoardPhotoId;
     }
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhotoRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhotoRepository.java
@@ -2,5 +2,8 @@ package com.ddd.moodof.domain.model.board.photo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
+    Optional<BoardPhoto> findFirstByBoardIdOrderByLastModifiedDateDesc(Long boardId);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhotoRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/board/photo/BoardPhotoRepository.java
@@ -2,8 +2,11 @@ package com.ddd.moodof.domain.model.board.photo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
     Optional<BoardPhoto> findFirstByBoardIdOrderByLastModifiedDateDesc(Long boardId);
+
+    List<BoardPhoto> findAllByBoardIdAndUserId(Long boardId, Long userId);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/storage/photo/StoragePhotoQueryRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/storage/photo/StoragePhotoQueryRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface StoragePhotoQueryRepository {
     StoragePhotoDTO.StoragePhotoPageResponse findPageExcludeTrash(Long userId, Pageable pageable, List<Long> tagIds);
 
-    StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id);
+    StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id, List<Long> tagIds);
 }

--- a/src/main/java/com/ddd/moodof/domain/model/storage/photo/StoragePhotoRepository.java
+++ b/src/main/java/com/ddd/moodof/domain/model/storage/photo/StoragePhotoRepository.java
@@ -2,8 +2,11 @@ package com.ddd.moodof.domain.model.storage.photo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StoragePhotoRepository extends JpaRepository<StoragePhoto, Long> {
 
-    boolean existsByIdAndUserId(Long id, Long userId);
+    boolean existsByIdInAndUserId(List<Long> ids, Long userId);
 
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
@@ -73,12 +73,12 @@ public class AcceptanceTest {
         return userRepository.save(new User(null, "test@test.com", "password", "nickname", "profileUrl", null, null, AuthProvider.google, "providerId"));
     }
 
-    protected CategoryDTO.CategoryResponse 카테고리_생성(Long userId, String title, Long previousId){
-        CategoryDTO.CreateCategoryRequest request = new CategoryDTO.CreateCategoryRequest(title,previousId);
+    protected CategoryDTO.CategoryResponse 카테고리_생성(Long userId, String title, Long previousId) {
+        CategoryDTO.CreateCategoryRequest request = new CategoryDTO.CreateCategoryRequest(title, previousId);
         return postWithLogin(request, API_CATEGORY, CategoryDTO.CategoryResponse.class, userId);
     }
 
-    protected CategoryDTO.CategoryResponse 카테고리_순서_변경(Long id,Long previousId, Long userId, String property){
+    protected CategoryDTO.CategoryResponse 카테고리_순서_변경(Long id, Long previousId, Long userId, String property) {
         CategoryDTO.UpdateOrderCategoryRequest request = new CategoryDTO.UpdateOrderCategoryRequest(previousId);
         return putPropertyWithLogin(request, id, API_CATEGORY, CategoryDTO.CategoryResponse.class, userId, property);
     }
@@ -232,7 +232,24 @@ public class AcceptanceTest {
             String token = tokenProvider.createToken(userId);
 
             mockMvc.perform(MockMvcRequestBuilders.delete(uri + "/{id}", resourceId)
+                    .header(AUTHORIZATION, BEARER + token))
+                    .andExpect(MockMvcResultMatchers.status().isNoContent())
+                    .andReturn();
+
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new AssertionError("test fails");
+        }
+    }
+
+    protected <T> void deleteListWithLogin(String uri, T request, Long userId) {
+        try {
+            String token = tokenProvider.createToken(userId);
+
+
+            mockMvc.perform(MockMvcRequestBuilders.delete(uri)
                     .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
                     .header(AUTHORIZATION, BEARER + token))
                     .andExpect(MockMvcResultMatchers.status().isNoContent())
                     .andReturn();
@@ -248,8 +265,8 @@ public class AcceptanceTest {
         return postWithLogin(request, API_TAG_ATTACHMENT, TagAttachmentDTO.TagAttachmentResponse.class, userId);
     }
 
-    protected BoardPhotoDTO.BoardPhotoResponse 보드_사진_생성(Long userId, Long storagePhotoId, Long boardId) {
-        BoardPhotoDTO.AddBoardPhoto request = new BoardPhotoDTO.AddBoardPhoto(storagePhotoId, boardId);
-        return postWithLogin(request, API_BOARD_PHOTO, BoardPhotoDTO.BoardPhotoResponse.class, userId);
+    protected List<BoardPhotoDTO.BoardPhotoResponse> 보드_사진_복수_생성(Long userId, List<Long> storagePhotoIds, Long boardId) {
+        BoardPhotoDTO.AddBoardPhoto request = new BoardPhotoDTO.AddBoardPhoto(storagePhotoIds, boardId);
+        return postListWithLogin(request, API_BOARD_PHOTO, BoardPhotoDTO.BoardPhotoResponse.class, userId);
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/BoardPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/BoardPhotoAcceptanceTest.java
@@ -47,6 +47,18 @@ public class BoardPhotoAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 보드사진을_조회한다() {
+        // given
+        보드_사진_복수_생성(userId, List.of(storagePhoto.getId(), storagePhoto2.getId()), board.getId());
+
+        // when
+        List<BoardPhotoDTO.BoardPhotoResponse> responses = getListWithLogin(API_BOARD_PHOTO + "?boardId=" + board.getId(), BoardPhotoDTO.BoardPhotoResponse.class, userId);
+
+        // then
+        assertThat(responses.size()).isEqualTo(2);
+    }
+
+    @Test
     void 보드에서_보관함사진을_제거한다() {
         // given
         List<BoardPhotoDTO.BoardPhotoResponse> responses = 보드_사진_복수_생성(userId, List.of(storagePhoto.getId()), board.getId());

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -152,12 +152,9 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         BoardDTO.BoardResponse board1 = 보드_생성(userId, 0L, category1.getId(), "board-1");
         BoardDTO.BoardResponse board2 = 보드_생성(userId, board1.getId(), category1.getId(), "board-2");
         BoardDTO.BoardResponse board3 = 보드_생성(userId, 0L, category2.getId(), "board-3");
-        보드_사진_생성(userId, storagePhoto1.getId(), board1.getId());
-        보드_사진_생성(userId, storagePhoto2.getId(), board1.getId());
-        보드_사진_생성(userId, storagePhoto2.getId(), board2.getId());
-        보드_사진_생성(userId, storagePhoto2.getId(), board3.getId());
-        보드_사진_생성(userId, storagePhoto3.getId(), board1.getId());
-        보드_사진_생성(userId, storagePhoto4.getId(), board2.getId());
+        보드_사진_복수_생성(userId, List.of(storagePhoto1.getId(), storagePhoto2.getId(), storagePhoto3.getId()), board1.getId());
+        보드_사진_복수_생성(userId, List.of(storagePhoto2.getId(), storagePhoto4.getId()), board2.getId());
+        보드_사진_복수_생성(userId, List.of(storagePhoto2.getId()), board3.getId());
         TagDTO.TagResponse tag1 = 태그_생성(userId, "tag-1");
         TagDTO.TagResponse tag2 = 태그_생성(userId, "tag-2");
         태그붙이기_생성(userId, storagePhoto2.getId(), tag1.getId());

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -94,6 +94,7 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
     @Test
     void 사진보관함_페이지_태그별_조회() {
         // given
+        StoragePhotoDTO.StoragePhotoResponse noTag = 보관함사진_생성(userId, "0", "0");
         StoragePhotoDTO.StoragePhotoResponse third = 보관함사진_생성(userId, "1", "1");
         StoragePhotoDTO.StoragePhotoResponse noContain = 보관함사진_생성(userId, "2", "2");
         StoragePhotoDTO.StoragePhotoResponse second = 보관함사진_생성(userId, "3", "3");
@@ -115,7 +116,7 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
                 .queryParam("size", 2)
                 .queryParam("sortBy", "lastModifiedDate")
                 .queryParam("descending", "true")
-                .queryParam("tagIds", tag1.getId(), tag2.getId())
+                .queryParam("tagIds", 0L, tag1.getId(), tag2.getId())
                 .build().toUriString();
 
         StoragePhotoDTO.StoragePhotoPageResponse response = getWithLogin(uri, StoragePhotoDTO.StoragePhotoPageResponse.class, userId);
@@ -161,10 +162,11 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         TagDTO.TagResponse tag2 = 태그_생성(userId, "tag-2");
         태그붙이기_생성(userId, storagePhoto2.getId(), tag1.getId());
         태그붙이기_생성(userId, storagePhoto2.getId(), tag2.getId());
+        태그붙이기_생성(userId, storagePhoto5.getId(), tag2.getId());
         보관함사진_휴지통_이동(List.of(storagePhoto3.getId(), storagePhoto4.getId()), userId);
 
         // when
-        StoragePhotoDTO.StoragePhotoDetailResponse response = getWithLogin(API_STORAGE_PHOTO + "/" + storagePhoto2.getId(), StoragePhotoDTO.StoragePhotoDetailResponse.class, userId);
+        StoragePhotoDTO.StoragePhotoDetailResponse response = getWithLogin(API_STORAGE_PHOTO + "/" + storagePhoto2.getId() + "?tagIds=0," + tag2.getId(), StoragePhotoDTO.StoragePhotoDetailResponse.class, userId);
 
         // then
         assertAll(

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -87,7 +87,8 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.getStoragePhotos().size()).isEqualTo(3),
                 () -> assertThat(response.getStoragePhotos().get(0)).usingRecursiveComparison().isEqualTo(top),
                 () -> assertThat(response.getStoragePhotos().get(1)).usingRecursiveComparison().isEqualTo(second),
-                () -> assertThat(response.getTotalPageCount()).isEqualTo(2)
+                () -> assertThat(response.getTotalPageCount()).isEqualTo(2),
+                () -> assertThat(response.getTotalStoragePhotoCount()).isEqualTo(4)
         );
     }
 
@@ -126,7 +127,8 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.getStoragePhotos().size()).isEqualTo(2),
                 () -> assertThat(response.getStoragePhotos().get(0)).usingRecursiveComparison().isEqualTo(top),
                 () -> assertThat(response.getStoragePhotos().get(1)).usingRecursiveComparison().isEqualTo(second),
-                () -> assertThat(response.getTotalPageCount()).isEqualTo(2)
+                () -> assertThat(response.getTotalPageCount()).isEqualTo(2),
+                () -> assertThat(response.getTotalStoragePhotoCount()).isEqualTo(4)
         );
     }
 


### PR DESCRIPTION
resolve #45 

상세조회 조건
- tagId [] (optional)
- 미분류 tagId는 0 이다

BoardPhoto
- storagePhotoId [] 생성
- 사진 보관함 사진 개수
- 순서 (previousBoardPhotoId)
- 리스트 조회 (전체 반환)

StoragePhoto 삭제시 (휴지통 30일 이후) BoardPhoto에서도 삭제 해야될 것 같아 Todo 하나 남겨뒀습니다!