### PR TITLE
feat: 태그 생성시 TagAttachment도 같이 생성된다

### DIFF
--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/MockDataLoader.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/MockDataLoader.java
@@ -26,6 +26,7 @@ public class MockDataLoader implements ApplicationRunner {
     private final StoragePhotoService storagePhotoService;
     private final TagAttachmentService tagAttachmentService;
     private final TagService tagService;
+    private final TagCreator tagCreator;
     private final TrashPhotoService trashPhotoService;
 
     @Value("${dev.user.email}")
@@ -57,18 +58,14 @@ public class MockDataLoader implements ApplicationRunner {
         BoardDTO.BoardResponse 보드3 = boardService.create(userId, new BoardDTO.CreateBoard(보드2.getId(), 카테고리1.getId(), "보드 3"));
         BoardDTO.BoardResponse 보드4 = boardService.create(userId, new BoardDTO.CreateBoard(0L, 카테고리2.getId(), "보드 4"));
         BoardDTO.BoardResponse 보드5 = boardService.create(userId, new BoardDTO.CreateBoard(보드4.getId(), 카테고리2.getId(), "보드 5"));
-        TagDTO.TagResponse 태그1 = tagService.create(new TagDTO.CreateRequest("태그 1"), userId);
-        TagDTO.TagResponse 태그2 = tagService.create(new TagDTO.CreateRequest("태그 2"), userId);
-        TagDTO.TagResponse 태그3 = tagService.create(new TagDTO.CreateRequest("태그 3"), userId);
-        TagDTO.TagResponse 태그4 = tagService.create(new TagDTO.CreateRequest("태그 4"), userId);
-        tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진1.getId(), 태그1.getId()));
-        tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진1.getId(), 태그2.getId()));
-        tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진1.getId(), 태그3.getId()));
+        TagDTO.TagCreatedResponse 태그1 = tagCreator.create("태그 1", userId, 사진1.getId());
+        TagDTO.TagCreatedResponse 태그2 = tagCreator.create("태그 2", userId, 사진1.getId());
+        TagDTO.TagCreatedResponse 태그3 = tagCreator.create("태그 3", userId, 사진1.getId());
+        TagDTO.TagCreatedResponse 태그4 = tagCreator.create("태그 4", userId, 사진4.getId());
         tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진2.getId(), 태그1.getId()));
         tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진2.getId(), 태그2.getId()));
         tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진3.getId(), 태그3.getId()));
         tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진3.getId(), 태그1.getId()));
-        tagAttachmentService.create(userId, new TagAttachmentDTO.CreateTagAttachment(사진4.getId(), 태그4.getId()));
         trashPhotoService.add(userId, new TrashPhotoDTO.CreateTrashPhotos(List.of(사진4.getId(), 사진5.getId())));
     }
 

--- a/src/main/java/com/ddd/moodof/adapter/presentation/TagController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/TagController.java
@@ -1,6 +1,7 @@
 package com.ddd.moodof.adapter.presentation;
 
 import com.ddd.moodof.adapter.presentation.api.TagAPI;
+import com.ddd.moodof.application.TagCreator;
 import com.ddd.moodof.application.TagService;
 import com.ddd.moodof.application.dto.TagDTO;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.net.URI;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -16,7 +16,9 @@ import java.util.List;
 @RestController
 public class TagController implements TagAPI {
     public static final String API_TAG = "/api/tags";
+
     private final TagService tagService;
+    private final TagCreator tagCreator;
 
     @Override
     @GetMapping
@@ -27,11 +29,11 @@ public class TagController implements TagAPI {
 
     @Override
     @PostMapping
-    public ResponseEntity<TagDTO.TagResponse> create(
+    public ResponseEntity<TagDTO.TagCreatedResponse> createWithTagAttachment(
             @RequestBody @Valid TagDTO.CreateRequest request,
             @LoginUserId Long userId) {
-        TagDTO.TagResponse response = tagService.create(request, userId);
-        return ResponseEntity.created(URI.create(API_TAG + "/" + response.getId())).body(response);
+        TagDTO.TagCreatedResponse response = tagCreator.create(request.getName(), userId, request.getStoragePhotoId());
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/TagAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/TagAPI.java
@@ -18,7 +18,7 @@ public interface TagAPI {
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @PostMapping
-    ResponseEntity<TagDTO.TagResponse> create(@RequestBody @Valid TagDTO.CreateRequest request, @ApiIgnore @LoginUserId Long userId);
+    ResponseEntity<TagDTO.TagCreatedResponse> createWithTagAttachment(@RequestBody @Valid TagDTO.CreateRequest request, @ApiIgnore @LoginUserId Long userId);
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @DeleteMapping("/{id}")

--- a/src/main/java/com/ddd/moodof/application/TagCreator.java
+++ b/src/main/java/com/ddd/moodof/application/TagCreator.java
@@ -1,0 +1,30 @@
+package com.ddd.moodof.application;
+
+import com.ddd.moodof.application.dto.TagAttachmentDTO;
+import com.ddd.moodof.application.dto.TagDTO;
+import com.ddd.moodof.domain.model.storage.photo.StoragePhotoRepository;
+import com.ddd.moodof.domain.model.tag.Tag;
+import com.ddd.moodof.domain.model.tag.TagRepository;
+import com.ddd.moodof.domain.model.tag.attachment.TagAttachment;
+import com.ddd.moodof.domain.model.tag.attachment.TagAttachmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class TagCreator {
+    private final TagRepository tagRepository;
+    private final TagAttachmentRepository tagAttachmentRepository;
+    private final StoragePhotoRepository storagePhotoRepository;
+
+    @Transactional
+    public TagDTO.TagCreatedResponse create(String name, Long userId, Long storagePhotoId) {
+        if (!storagePhotoRepository.existsByIdAndUserId(storagePhotoId, userId)) {
+            throw new IllegalArgumentException("태그 생성자의 아이디 및 StoragePhotoId와 일치하는 StoragePhoto가 존재하지 않습니다.");
+        }
+        Tag tag = tagRepository.save(new Tag(null, userId, name, null, null));
+        TagAttachment tagAttachment = tagAttachmentRepository.save(new TagAttachment(null, userId, storagePhotoId, tag.getId(), null, null));
+        return new TagDTO.TagCreatedResponse(tag.getId(), tag.getUserId(), tag.getName(), tag.getCreatedDate(), tag.getLastModifiedDate(), TagAttachmentDTO.TagAttachmentResponse.from(tagAttachment));
+    }
+}

--- a/src/main/java/com/ddd/moodof/application/TagService.java
+++ b/src/main/java/com/ddd/moodof/application/TagService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -19,21 +18,9 @@ public class TagService {
         return TagDTO.TagResponse.listFrom(allByUserId);
     }
 
-    public TagDTO.TagResponse create(TagDTO.CreateRequest request, Long userId) {
-        Optional<Tag> tagExist = tagRepository.findTagByNameAndUserId(request.getName(), userId);
-        if (tagExist.isPresent()) {
-            throw new IllegalArgumentException("존재하는 태그 입니다.");
-        }
-        Tag save = tagRepository.save(request.toEntity(userId, request.getName()));
-        return TagDTO.TagResponse.from(save);
-    }
-
     public void delete(Long id, Long userId) {
         Tag tag = tagRepository.findTagByIdAndUserId(id, userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 태그 정보입니다. " + id + " / " + userId));
-        if (userId.compareTo(tag.getUserId()) != 0) {
-            throw new IllegalArgumentException("요청 응답 유저의 값이 다른 정보입니다.");
-        }
         tagRepository.deleteById(tag.getId());
     }
 

--- a/src/main/java/com/ddd/moodof/application/dto/TagDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/TagDTO.java
@@ -17,18 +17,9 @@ public class TagDTO {
     @AllArgsConstructor
     @Getter
     public static class CreateRequest {
+        private Long storagePhotoId;
         @NotBlank
         private String name;
-
-        public Tag toEntity(Long userId, String name) {
-            return Tag.builder()
-                    .id(null)
-                    .userId(userId)
-                    .name(name)
-                    .createdDate(null)
-                    .lastModifiedDate(null)
-                    .build();
-        }
     }
 
     @NoArgsConstructor
@@ -48,7 +39,6 @@ public class TagDTO {
                     .build();
         }
     }
-
 
     @NoArgsConstructor
     @AllArgsConstructor
@@ -80,5 +70,17 @@ public class TagDTO {
                     .lastModifiedDate(tag.getLastModifiedDate())
                     .build()).collect(Collectors.toList());
         }
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class TagCreatedResponse {
+        private Long id;
+        private Long userId;
+        private String name;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastModifiedDate;
+        private TagAttachmentDTO.TagAttachmentResponse tagAttachment;
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
@@ -73,12 +73,12 @@ public class AcceptanceTest {
         return userRepository.save(new User(null, "test@test.com", "password", "nickname", "profileUrl", null, null, AuthProvider.google, "providerId"));
     }
 
-    protected CategoryDTO.CategoryResponse 카테고리_생성(Long userId, String title, Long previousId){
-        CategoryDTO.CreateCategoryRequest request = new CategoryDTO.CreateCategoryRequest(title,previousId);
+    protected CategoryDTO.CategoryResponse 카테고리_생성(Long userId, String title, Long previousId) {
+        CategoryDTO.CreateCategoryRequest request = new CategoryDTO.CreateCategoryRequest(title, previousId);
         return postWithLogin(request, API_CATEGORY, CategoryDTO.CategoryResponse.class, userId);
     }
 
-    protected CategoryDTO.CategoryResponse 카테고리_순서_변경(Long id,Long previousId, Long userId, String property){
+    protected CategoryDTO.CategoryResponse 카테고리_순서_변경(Long id, Long previousId, Long userId, String property) {
         CategoryDTO.UpdateOrderCategoryRequest request = new CategoryDTO.UpdateOrderCategoryRequest(previousId);
         return putPropertyWithLogin(request, id, API_CATEGORY, CategoryDTO.CategoryResponse.class, userId, property);
     }
@@ -92,9 +92,25 @@ public class AcceptanceTest {
         return postListWithLogin(new TrashPhotoDTO.CreateTrashPhotos(storagePhotoIds), API_TRASH_PHOTO, TrashPhotoDTO.TrashPhotoCreatedResponse.class, userId);
     }
 
-    protected TagDTO.TagResponse 태그_생성(Long userId, String name) {
-        TagDTO.CreateRequest request = new TagDTO.CreateRequest(name);
-        return postWithLogin(request, API_TAG, TagDTO.TagResponse.class, userId);
+    protected TagDTO.TagCreatedResponse 태그_생성(Long userId, Long storagePhotoId, String name) {
+        TagDTO.CreateRequest request = new TagDTO.CreateRequest(storagePhotoId, name);
+        try {
+            String token = tokenProvider.createToken(userId);
+            String body = objectMapper.writeValueAsString(request);
+
+            MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post(API_TAG)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(body)
+                    .header(AUTHORIZATION, BEARER + token))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andReturn();
+
+            return objectMapper.readValue(result.getResponse().getContentAsString(), TagDTO.TagCreatedResponse.class);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new AssertionError("test fails");
+        }
     }
 
     protected TagDTO.TagResponse 태그_수정(Long id, Long userId, String name) {

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -100,14 +100,11 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         StoragePhotoDTO.StoragePhotoResponse trash = 보관함사진_생성(userId, "4", "4");
         StoragePhotoDTO.StoragePhotoResponse top = 보관함사진_생성(userId, "5", "5");
         보관함사진_휴지통_이동(Collections.singletonList(trash.getId()), userId);
-        TagDTO.TagResponse tag1 = 태그_생성(userId, "name1");
-        TagDTO.TagResponse tag2 = 태그_생성(userId, "name2");
-        TagDTO.TagResponse noSearch = 태그_생성(userId, "name3");
-        태그붙이기_생성(userId, second.getId(), tag2.getId());
-        태그붙이기_생성(userId, third.getId(), tag1.getId());
+        TagDTO.TagCreatedResponse tag1 = 태그_생성(userId, third.getId(), "name1");
+        TagDTO.TagCreatedResponse tag2 = 태그_생성(userId, second.getId(), "name2");
+        TagDTO.TagCreatedResponse noSearch = 태그_생성(userId, noContain.getId(), "name3");
         태그붙이기_생성(userId, trash.getId(), tag1.getId());
         태그붙이기_생성(userId, top.getId(), tag1.getId());
-        태그붙이기_생성(userId, noContain.getId(), noSearch.getId());
 
         // when
         String uri = UriComponentsBuilder.fromUriString(API_STORAGE_PHOTO)
@@ -157,10 +154,8 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         보드_사진_생성(userId, storagePhoto2.getId(), board3.getId());
         보드_사진_생성(userId, storagePhoto3.getId(), board1.getId());
         보드_사진_생성(userId, storagePhoto4.getId(), board2.getId());
-        TagDTO.TagResponse tag1 = 태그_생성(userId, "tag-1");
-        TagDTO.TagResponse tag2 = 태그_생성(userId, "tag-2");
-        태그붙이기_생성(userId, storagePhoto2.getId(), tag1.getId());
-        태그붙이기_생성(userId, storagePhoto2.getId(), tag2.getId());
+        TagDTO.TagCreatedResponse tag1 = 태그_생성(userId, storagePhoto2.getId(), "tag-1");
+        TagDTO.TagCreatedResponse tag2 = 태그_생성(userId, storagePhoto2.getId(), "tag-2");
         보관함사진_휴지통_이동(List.of(storagePhoto3.getId(), storagePhoto4.getId()), userId);
 
         // when

--- a/src/test/java/com/ddd/moodof/acceptance/TagAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/TagAcceptanceTest.java
@@ -1,8 +1,8 @@
 package com.ddd.moodof.acceptance;
 
+import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import com.ddd.moodof.application.dto.TagDTO;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 
@@ -12,12 +12,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class TagAcceptanceTest extends AcceptanceTest {
     @Test
-    public void 유저아이디_태그_전체_조회() throws Exception {
+    public void 유저아이디_태그_전체_조회() {
         // given
-        태그_생성(userId, "tag1");
-        태그_생성(userId, "tag2");
-        태그_생성(userId, "tag3");
-        TagDTO.TagResponse tagResponse = 태그_생성(userId, "tag4");
+        StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "photoUri", "representativeColor");
+        태그_생성(userId, storagePhoto.getId(), "tag1");
+        태그_생성(userId, storagePhoto.getId(), "tag2");
+        태그_생성(userId, storagePhoto.getId(), "tag3");
+        태그_생성(userId, storagePhoto.getId(), "tag4");
 
         // when
         String uri = API_TAG;
@@ -31,12 +32,12 @@ public class TagAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    public void 태그를_생성한다() throws Exception {
-
+    public void 태그를_생성한다() {
         // given
+        StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "photoUri", "representativeColor");
 
         // when
-        TagDTO.TagResponse response = 태그_생성(userId, "name1");
+        TagDTO.TagCreatedResponse response = 태그_생성(userId, storagePhoto.getId(), "name1");
 
         // then
         assertAll(
@@ -44,42 +45,34 @@ public class TagAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.getUserId()).isEqualTo(userId),
                 () -> assertThat(response.getName()).isEqualTo("name1"),
                 () -> assertThat(response.getCreatedDate()).isNotNull(),
-                () -> assertThat(response.getLastModifiedDate()).isNotNull()
+                () -> assertThat(response.getLastModifiedDate()).isNotNull(),
+                () -> assertThat(response.getTagAttachment().getId()).isNotNull(),
+                () -> assertThat(response.getTagAttachment().getStoragePhotoId()).isEqualTo(storagePhoto.getId()),
+                () -> assertThat(response.getTagAttachment().getTagId()).isEqualTo(response.getId())
         );
     }
 
     @Test
-    public void 태그를_삭제한다() throws Exception {
+    public void 태그를_삭제한다() {
         // given
-        태그_생성(userId, "name1");
-        TagDTO.TagResponse response = 태그_생성(userId, "name2");
+        StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "photoUri", "representativeColor");
+        태그_생성(userId, storagePhoto.getId(), "name1");
+        TagDTO.TagCreatedResponse response = 태그_생성(userId, storagePhoto.getId(), "name2");
 
         // when
-        태그_리스트_출력(userId);
         deleteWithLogin(API_TAG, response.getId(), userId);
-        태그_리스트_출력(userId);
     }
 
     @Test
-    public void 태그_수정() throws Exception {
+    public void 태그_수정() {
         // given
-        TagDTO.TagResponse createList = 태그_생성(userId, "name1");
+        StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "photoUri", "representativeColor");
+        TagDTO.TagCreatedResponse tag = 태그_생성(userId, storagePhoto.getId(), "name1");
 
         // when
-        TagDTO.TagResponse updateList = 태그_수정(createList.getId(), userId, "name2");
+        TagDTO.TagResponse updateList = 태그_수정(tag.getId(), userId, "name2");
 
         // then
         assertThat(updateList.getName()).isEqualTo("name2");
-        System.err.println(updateList.getName());
-
-    }
-
-    public void 태그_리스트_출력(Long userId) throws Exception {
-        String uri = UriComponentsBuilder.fromUriString(API_TAG)
-                .build().toUriString();
-        List<TagDTO.TagResponse> reponseList = getListWithLogin(uri, TagDTO.TagResponse.class, userId);
-        for (TagDTO.TagResponse r : reponseList) {
-            System.err.println("userId: " + userId + " id: " + r.getId());
-        }
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/TagAttachmentAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/TagAttachmentAcceptanceTest.java
@@ -12,14 +12,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class TagAttachmentAcceptanceTest extends AcceptanceTest {
     private StoragePhotoDTO.StoragePhotoResponse storagePhoto;
-    private TagDTO.TagResponse tag;
+    private TagDTO.TagCreatedResponse tag;
 
     @Override
     @BeforeEach
     void setUp() {
         super.setUp();
         storagePhoto = 보관함사진_생성(userId, "photoUri", "representativeColor");
-        tag = 태그_생성(userId, "tag");
+        tag = 태그_생성(userId, storagePhoto.getId(), "tag");
     }
 
     @Test


### PR DESCRIPTION
resolve #53 

이전 회의에서 태그 생성 UI에 대한 이야기가 나왔는데, StoragePhoto 상세 조회 화면에서 태그가 생성된다는 것을 알게 되었습니다.

![image](https://user-images.githubusercontent.com/52931057/119518177-42a77b00-bdb3-11eb-8ce3-441f92393aa8.png)

이외의 태그 생성 use case는 아직 없어, Tag 생성 API를 TagAttachment도 같이 생성되도록 변경하였습니다.
