### PR TITLE
refactor: API 주소 변경

### DIFF
--- a/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/TrashPhotoQuerydslRepository.java
+++ b/src/main/java/com/ddd/moodof/adapter/infrastructure/persistence/querydsl/TrashPhotoQuerydslRepository.java
@@ -47,6 +47,7 @@ public class TrashPhotoQuerydslRepository implements TrashPhotoQueryRepository {
                 .applyPagination(pageable, jpaQuery)
                 .fetch();
 
-        return new TrashPhotoDTO.TrashPhotoPageResponse(paginationUtils.getTotalPageCount(jpaQuery.fetchCount(), pageable.getPageSize()), trashPhotoResponses);
+        long totalCount = jpaQuery.fetchCount();
+        return new TrashPhotoDTO.TrashPhotoPageResponse(totalCount, paginationUtils.getTotalPageCount(totalCount, pageable.getPageSize()), trashPhotoResponses);
     }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/StoragePhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/StoragePhotoController.java
@@ -2,7 +2,9 @@ package com.ddd.moodof.adapter.presentation;
 
 import com.ddd.moodof.adapter.presentation.api.StoragePhotoAPI;
 import com.ddd.moodof.application.StoragePhotoService;
+import com.ddd.moodof.application.TrashPhotoService;
 import com.ddd.moodof.application.dto.StoragePhotoDTO;
+import com.ddd.moodof.application.dto.TrashPhotoDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +20,7 @@ public class StoragePhotoController implements StoragePhotoAPI {
     public static final String API_STORAGE_PHOTO = "/api/storage-photos";
 
     private final StoragePhotoService storagePhotoService;
+    private final TrashPhotoService trashPhotoService;
 
     @Override
     @PostMapping
@@ -57,8 +60,8 @@ public class StoragePhotoController implements StoragePhotoAPI {
 
     @Override
     @DeleteMapping
-    public ResponseEntity<Void> delete(@LoginUserId Long userId, @RequestBody StoragePhotoDTO.DeleteStoragePhotos request) {
-        storagePhotoService.delete(userId, request);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<List<TrashPhotoDTO.TrashPhotoCreatedResponse>> addToTrash(@LoginUserId Long userId, @RequestBody TrashPhotoDTO.CreateTrashPhotos request) {
+        List<TrashPhotoDTO.TrashPhotoCreatedResponse> response = trashPhotoService.add(userId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/TrashPhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/TrashPhotoController.java
@@ -38,8 +38,8 @@ public class TrashPhotoController implements TrashPhotoAPI {
 
     @Override
     @DeleteMapping
-    public ResponseEntity<Void> cancel(@LoginUserId Long userId, @RequestBody TrashPhotoDTO.CancelTrashPhotos request) {
-        trashPhotoService.cancel(request, userId);
+    public ResponseEntity<Void> delete(@LoginUserId Long userId, @RequestBody TrashPhotoDTO.TrashPhotosRequest request) {
+        trashPhotoService.delete(request, userId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/TrashPhotoController.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/TrashPhotoController.java
@@ -2,6 +2,7 @@ package com.ddd.moodof.adapter.presentation;
 
 import com.ddd.moodof.adapter.presentation.api.TrashPhotoAPI;
 import com.ddd.moodof.application.TrashPhotoService;
+import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import com.ddd.moodof.application.dto.TrashPhotoDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,12 @@ public class TrashPhotoController implements TrashPhotoAPI {
         return ResponseEntity.ok(responses);
     }
 
+    @PostMapping("/restore")
+    public ResponseEntity<List<StoragePhotoDTO.StoragePhotoResponse>> restore(@LoginUserId Long userId, @RequestBody TrashPhotoDTO.TrashPhotosRequest request) {
+        List<StoragePhotoDTO.StoragePhotoResponse> responses = trashPhotoService.restore(request, userId);
+        return ResponseEntity.ok(responses);
+    }
+
     @Override
     @GetMapping
     public ResponseEntity<TrashPhotoDTO.TrashPhotoPageResponse> findPage(
@@ -39,7 +46,7 @@ public class TrashPhotoController implements TrashPhotoAPI {
     @Override
     @DeleteMapping
     public ResponseEntity<Void> delete(@LoginUserId Long userId, @RequestBody TrashPhotoDTO.TrashPhotosRequest request) {
-        trashPhotoService.delete(request, userId);
+        trashPhotoService.deletePhoto(request, userId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/StoragePhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/StoragePhotoAPI.java
@@ -2,6 +2,7 @@ package com.ddd.moodof.adapter.presentation.api;
 
 import com.ddd.moodof.adapter.presentation.LoginUserId;
 import com.ddd.moodof.application.dto.StoragePhotoDTO;
+import com.ddd.moodof.application.dto.TrashPhotoDTO;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiParam;
 import org.springframework.http.ResponseEntity;
@@ -32,5 +33,5 @@ public interface StoragePhotoAPI {
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @DeleteMapping
-    ResponseEntity<Void> delete(@ApiIgnore @LoginUserId Long userId, @RequestBody StoragePhotoDTO.DeleteStoragePhotos request);
+    ResponseEntity<List<TrashPhotoDTO.TrashPhotoCreatedResponse>> addToTrash(@ApiIgnore @LoginUserId Long userId, @RequestBody TrashPhotoDTO.CreateTrashPhotos request);
 }

--- a/src/main/java/com/ddd/moodof/adapter/presentation/api/TrashPhotoAPI.java
+++ b/src/main/java/com/ddd/moodof/adapter/presentation/api/TrashPhotoAPI.java
@@ -26,5 +26,5 @@ public interface TrashPhotoAPI {
 
     @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
     @DeleteMapping
-    ResponseEntity<Void> cancel(@ApiIgnore @LoginUserId Long userId, @RequestBody TrashPhotoDTO.CancelTrashPhotos request);
+    ResponseEntity<Void> delete(@ApiIgnore @LoginUserId Long userId, @RequestBody TrashPhotoDTO.TrashPhotosRequest request);
 }

--- a/src/main/java/com/ddd/moodof/application/StoragePhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/StoragePhotoService.java
@@ -45,4 +45,9 @@ public class StoragePhotoService {
     public StoragePhotoDTO.StoragePhotoDetailResponse findDetail(Long userId, Long id, List<Long> tagIds) {
         return storagePhotoQueryRepository.findDetail(userId, id, tagIds);
     }
+
+    public List<StoragePhotoDTO.StoragePhotoResponse> findAllById(List<Long> storagePhotoIds) {
+        List<StoragePhoto> storagePhotos = storagePhotoRepository.findAllById(storagePhotoIds);
+        return StoragePhotoDTO.StoragePhotoResponse.listFrom(storagePhotos);
+    }
 }

--- a/src/main/java/com/ddd/moodof/application/TrashPhotoService.java
+++ b/src/main/java/com/ddd/moodof/application/TrashPhotoService.java
@@ -1,6 +1,7 @@
 package com.ddd.moodof.application;
 
 import com.ddd.moodof.adapter.infrastructure.persistence.PaginationUtils;
+import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import com.ddd.moodof.application.dto.TrashPhotoDTO;
 import com.ddd.moodof.domain.model.trash.photo.TrashPhoto;
 import com.ddd.moodof.domain.model.trash.photo.TrashPhotoQueryRepository;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -39,10 +41,14 @@ public class TrashPhotoService {
     }
 
     @Transactional
-    public void cancel(TrashPhotoDTO.CancelTrashPhotos request, Long userId) {
-        if (!trashPhotoRepository.existsByIdInAndUserId(request.getTrashPhotoIds(), userId)) {
-            throw new IllegalArgumentException("요청과 일치하는 휴지통 사진이 없습니다.");
-        }
+    public void delete(TrashPhotoDTO.TrashPhotosRequest request, Long userId) {
+        List<TrashPhoto> trashPhotos = trashPhotoRepository.findAllById(request.getTrashPhotoIds());
+
+        List<Long> storagePhotoIds = trashPhotos.stream()
+                .map(TrashPhoto::getStoragePhotoId)
+                .collect(Collectors.toList());
+
+        storagePhotoService.delete(userId, new StoragePhotoDTO.DeleteStoragePhotos(storagePhotoIds));
         trashPhotoRepository.deleteAllByIdIn(request.getTrashPhotoIds());
     }
 }

--- a/src/main/java/com/ddd/moodof/application/dto/StoragePhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/StoragePhotoDTO.java
@@ -55,7 +55,7 @@ public class StoragePhotoDTO {
     public static class StoragePhotoPageResponse {
         private long totalStoragePhotoCount;
         private long totalPageCount;
-        private List<StoragePhotoResponse> storagePhotos;
+        private List<StoragePhotoResponse> data;
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/ddd/moodof/application/dto/TrashPhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/TrashPhotoDTO.java
@@ -64,8 +64,9 @@ public class TrashPhotoDTO {
     @Getter
     @AllArgsConstructor
     public static class TrashPhotoPageResponse {
+        private long totalTrashPhotoCount;
         private long totalPageCount;
-        private List<TrashPhotoResponse> responses;
+        private List<TrashPhotoResponse> data;
     }
 
     @NoArgsConstructor

--- a/src/main/java/com/ddd/moodof/application/dto/TrashPhotoDTO.java
+++ b/src/main/java/com/ddd/moodof/application/dto/TrashPhotoDTO.java
@@ -71,7 +71,7 @@ public class TrashPhotoDTO {
     @NoArgsConstructor
     @Getter
     @AllArgsConstructor
-    public static class CancelTrashPhotos {
+    public static class TrashPhotosRequest {
         private List<Long> trashPhotoIds;
     }
 }

--- a/src/main/java/com/ddd/moodof/domain/model/trash/photo/TrashPhoto.java
+++ b/src/main/java/com/ddd/moodof/domain/model/trash/photo/TrashPhoto.java
@@ -30,4 +30,8 @@ public class TrashPhoto {
 
     @LastModifiedDate
     private LocalDateTime lastModifiedDate;
+
+    public boolean isUserNotEqual(Long userId) {
+        return !this.userId.equals(userId);
+    }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/AcceptanceTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -258,7 +259,7 @@ public class AcceptanceTest {
         }
     }
 
-    protected <T> void deleteListWithLogin(String uri, T request, Long userId) {
+    protected <T> void deleteListWithLogin(String uri, T request, Long userId, ResultMatcher expectResult) {
         try {
             String token = tokenProvider.createToken(userId);
 
@@ -267,7 +268,7 @@ public class AcceptanceTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
                     .header(AUTHORIZATION, BEARER + token))
-                    .andExpect(MockMvcResultMatchers.status().isNoContent())
+                    .andExpect(expectResult)
                     .andReturn();
 
         } catch (Exception e) {

--- a/src/test/java/com/ddd/moodof/acceptance/BoardPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/BoardPhotoAcceptanceTest.java
@@ -6,6 +6,7 @@ import com.ddd.moodof.application.dto.CategoryDTO;
 import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -67,6 +68,6 @@ public class BoardPhotoAcceptanceTest extends AcceptanceTest {
         List<Long> boardPhotoIds = responses.stream()
                 .map(BoardPhotoDTO.BoardPhotoResponse::getId)
                 .collect(Collectors.toList());
-        deleteListWithLogin(API_BOARD_PHOTO, new BoardPhotoDTO.RemoveBoardPhotos(boardPhotoIds), userId);
+        deleteListWithLogin(API_BOARD_PHOTO, new BoardPhotoDTO.RemoveBoardPhotos(boardPhotoIds), userId, MockMvcResultMatchers.status().isNoContent());
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -7,6 +7,7 @@ import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import com.ddd.moodof.application.dto.TagDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
@@ -135,7 +136,7 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
         StoragePhotoDTO.StoragePhotoResponse storagePhotoResponse = 보관함사진_생성(userId, "uri", "color");
 
         // when then
-        deleteListWithLogin(API_STORAGE_PHOTO, new StoragePhotoDTO.DeleteStoragePhotos(List.of(storagePhotoResponse.getId())), userId);
+        deleteListWithLogin(API_STORAGE_PHOTO, new StoragePhotoDTO.DeleteStoragePhotos(List.of(storagePhotoResponse.getId())), userId, MockMvcResultMatchers.status().isOk());
     }
 
     @Test

--- a/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/StoragePhotoAcceptanceTest.java
@@ -85,9 +85,9 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-                () -> assertThat(response.getStoragePhotos().size()).isEqualTo(3),
-                () -> assertThat(response.getStoragePhotos().get(0)).usingRecursiveComparison().isEqualTo(top),
-                () -> assertThat(response.getStoragePhotos().get(1)).usingRecursiveComparison().isEqualTo(second),
+                () -> assertThat(response.getData().size()).isEqualTo(3),
+                () -> assertThat(response.getData().get(0)).usingRecursiveComparison().isEqualTo(top),
+                () -> assertThat(response.getData().get(1)).usingRecursiveComparison().isEqualTo(second),
                 () -> assertThat(response.getTotalPageCount()).isEqualTo(2),
                 () -> assertThat(response.getTotalStoragePhotoCount()).isEqualTo(4)
         );
@@ -122,9 +122,9 @@ public class StoragePhotoAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-                () -> assertThat(response.getStoragePhotos().size()).isEqualTo(2),
-                () -> assertThat(response.getStoragePhotos().get(0)).usingRecursiveComparison().isEqualTo(top),
-                () -> assertThat(response.getStoragePhotos().get(1)).usingRecursiveComparison().isEqualTo(second),
+                () -> assertThat(response.getData().size()).isEqualTo(2),
+                () -> assertThat(response.getData().get(0)).usingRecursiveComparison().isEqualTo(top),
+                () -> assertThat(response.getData().get(1)).usingRecursiveComparison().isEqualTo(second),
                 () -> assertThat(response.getTotalPageCount()).isEqualTo(2),
                 () -> assertThat(response.getTotalStoragePhotoCount()).isEqualTo(4)
         );

--- a/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
@@ -66,7 +66,7 @@ public class TrashPhotoAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 휴지통의_사진을_삭제한다() {
+    void 휴지통_사진을_삭제한다() {
         // given
         StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "uri", "representativeColor");
         List<TrashPhotoDTO.TrashPhotoCreatedResponse> responses = 보관함사진_휴지통_이동(List.of(storagePhoto.getId()), userId);
@@ -77,5 +77,22 @@ public class TrashPhotoAcceptanceTest extends AcceptanceTest {
 
         // when then
         deleteListWithLogin(API_TRASH_PHOTO, new TrashPhotoDTO.TrashPhotosRequest(trashPhotoIds), userId, MockMvcResultMatchers.status().isNoContent());
+    }
+
+    @Test
+    void 휴지통_사진을_복구한다() {
+        // given
+        StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "uri", "representativeColor");
+        List<TrashPhotoDTO.TrashPhotoCreatedResponse> trashPhotos = 보관함사진_휴지통_이동(List.of(storagePhoto.getId()), userId);
+
+        List<Long> trashPhotoIds = trashPhotos.stream()
+                .map(TrashPhotoDTO.TrashPhotoCreatedResponse::getId)
+                .collect(Collectors.toList());
+
+        // when
+        List<StoragePhotoDTO.StoragePhotoResponse> responses = postListWithLogin(new TrashPhotoDTO.TrashPhotosRequest(trashPhotoIds), API_TRASH_PHOTO + "/restore", StoragePhotoDTO.StoragePhotoResponse.class, userId);
+
+        // then
+        assertThat(responses.get(0)).usingRecursiveComparison().isEqualTo(storagePhoto);
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
@@ -59,9 +59,10 @@ public class TrashPhotoAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
+                () -> assertThat(response.getTotalTrashPhotoCount()).isEqualTo(3),
                 () -> assertThat(response.getTotalPageCount()).isEqualTo(2),
-                () -> assertThat(response.getResponses().get(0).getStoragePhoto()).usingRecursiveComparison().isEqualTo(storagePhoto3),
-                () -> assertThat(response.getResponses().get(0).getId()).isEqualTo(top.get(0).getId())
+                () -> assertThat(response.getData().get(0).getStoragePhoto()).usingRecursiveComparison().isEqualTo(storagePhoto3),
+                () -> assertThat(response.getData().get(0).getId()).isEqualTo(top.get(0).getId())
         );
     }
 

--- a/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
@@ -76,6 +76,6 @@ public class TrashPhotoAcceptanceTest extends AcceptanceTest {
                 .collect(Collectors.toList());
 
         // when then
-        deleteListWithLogin(API_TRASH_PHOTO, new TrashPhotoDTO.CancelTrashPhotos(trashPhotoIds), userId, MockMvcResultMatchers.status().isNoContent());
+        deleteListWithLogin(API_TRASH_PHOTO, new TrashPhotoDTO.TrashPhotosRequest(trashPhotoIds), userId, MockMvcResultMatchers.status().isNoContent());
     }
 }

--- a/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
+++ b/src/test/java/com/ddd/moodof/acceptance/TrashPhotoAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.ddd.moodof.acceptance;
 import com.ddd.moodof.application.dto.StoragePhotoDTO;
 import com.ddd.moodof.application.dto.TrashPhotoDTO;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
@@ -65,7 +66,7 @@ public class TrashPhotoAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 휴지통의_사진을_복구한다() {
+    void 휴지통의_사진을_삭제한다() {
         // given
         StoragePhotoDTO.StoragePhotoResponse storagePhoto = 보관함사진_생성(userId, "uri", "representativeColor");
         List<TrashPhotoDTO.TrashPhotoCreatedResponse> responses = 보관함사진_휴지통_이동(List.of(storagePhoto.getId()), userId);
@@ -75,6 +76,6 @@ public class TrashPhotoAcceptanceTest extends AcceptanceTest {
                 .collect(Collectors.toList());
 
         // when then
-        deleteListWithLogin(API_TRASH_PHOTO, new TrashPhotoDTO.CancelTrashPhotos(trashPhotoIds), userId);
+        deleteListWithLogin(API_TRASH_PHOTO, new TrashPhotoDTO.CancelTrashPhotos(trashPhotoIds), userId, MockMvcResultMatchers.status().isNoContent());
     }
 }


### PR DESCRIPTION
resolve #66 

- 여러 사진 휴지통으로 보내기
DELETE /storage-photos , body storagePhotoIds 배열
-> 200 OK, body에 trash-photos 배열
-> 대충 응답을 보고 아 휴지통으로 이동이 되는구나 할 수 있지 않을까, 단건이었으면 201 CREATED에 trash-photos location 헤더 를 넣어주는 식으로 표현 할 수 있겠다 라고 생각했습니다.

- 휴지통에서 여러 사진 복구
POST /trash-photos/restore, body trashPhotoIds 배열
-> 200 OK, body에 복구된 storage-photos 배열

- 휴지통 사진에서 사진 삭제 (보관함 사진 삭제)
DELETE /trash-photos, body trashPhotoIds 배열
-> 204

---
- 페이지 조회시 response의 필드를 data로 변경하였습니다.
- 휴지통 사진 목록 조회에 사진 총 개수를 추가하였습니다.
 